### PR TITLE
Chore: housekeeping

### DIFF
--- a/.devcontainer/config.json
+++ b/.devcontainer/config.json
@@ -1,0 +1,17 @@
+{
+    "result_backend": {
+        "redis": {
+            "url": "redis://redis:6379/0"
+        }
+    },
+    "state_backend": {
+        "redis": {
+            "url": "redis://redis:6379/0"
+        }
+    },
+    "broker": {
+        "amqp": {
+            "url": "amqp://rabbitmq:5672"
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
 {
 	"name": "Python 3",
 	"dockerComposeFile": [
-		"docker-compose.yaml"
+		"docker-compose.yaml",
+		"docker-compose-devcontainer.yaml"
 	],
 	"workspaceFolder": "/workspaces/project-mognet",
 	"service": "mognet",

--- a/.devcontainer/docker-compose-devcontainer.yaml
+++ b/.devcontainer/docker-compose-devcontainer.yaml
@@ -1,0 +1,32 @@
+version: "2.4"
+
+services:
+  mognet:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+      args:
+        VARIANT: "3.8"
+        INSTALL_NODE: "false"
+
+    mem_limit: 4g
+    cpus: 2
+    working_dir: /workspaces/project-mognet
+    volumes:
+      - ..:/workspaces/project-mognet:cached
+      - vscode_server_data:/home/vscode/.vscode-server
+      - cache:/home/vscode/.cache
+
+    command:
+      - bash
+      - -c
+      - |
+        set -e
+        sudo chown -R vscode:vscode /home/vscode/.vscode-server
+        sudo chown -R vscode:vscode /home/vscode/.cache
+        exec sleep infinity
+
+volumes:
+  results_backend_data: {}
+  vscode_server_data: {}
+  cache: {}

--- a/.devcontainer/docker-compose-devcontainer.yaml
+++ b/.devcontainer/docker-compose-devcontainer.yaml
@@ -17,6 +17,9 @@ services:
       - vscode_server_data:/home/vscode/.vscode-server
       - cache:/home/vscode/.cache
 
+    environment:
+      - MOGNET_CONFIG_FILE=/workspaces/project-mognet/.devcontainer/config.json
+
     command:
       - bash
       - -c

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -13,9 +13,9 @@ services:
 
   rabbitmq:
     image: rabbitmq:management
-    mem_limit: 512m
+    mem_limit: 1024m
     mem_reservation: 128m
-    cpus: 0.5
+    cpus: 1
     # Prevent huge memory usage by limiting the number
     # of file descriptors
     ulimits:

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
         hard: 8192
     ports:
       - 5672:5672
+      - 15672:15672
 
 volumes:
   results_backend_data: {}

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,31 +1,6 @@
 version: "2.4"
 
 services:
-  mognet:
-    build:
-      context: ..
-      dockerfile: .devcontainer/Dockerfile
-      args:
-        VARIANT: "3.8"
-        INSTALL_NODE: "false"
-
-    mem_limit: 4g
-    cpus: 2
-    working_dir: /workspaces/project-mognet
-    volumes:
-      - ..:/workspaces/project-mognet:cached
-      - vscode_server_data:/home/vscode/.vscode-server
-      - cache:/home/vscode/.cache
-
-    command:
-      - bash
-      - -c
-      - |
-        set -e
-        sudo chown -R vscode:vscode /home/vscode/.vscode-server
-        sudo chown -R vscode:vscode /home/vscode/.cache
-        exec sleep infinity
-
   redis:
     image: redis
     mem_limit: 128m
@@ -33,10 +8,8 @@ services:
     cpus: 0.25
     volumes:
       - results_backend_data:/data
-    networks:
-      default:
-        aliases:
-          - cps-results-backend
+    ports:
+      - 6379:6379
 
   rabbitmq:
     image: rabbitmq:management
@@ -49,8 +22,8 @@ services:
       nofile:
         soft: 8192
         hard: 8192
+    ports:
+      - 5672:5672
 
 volumes:
   results_backend_data: {}
-  vscode_server_data: {}
-  cache: {}

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E501,W503
+exclude = .git,__pycache__,docs/,build,dist,demo
+# max-complexity = 10

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Apply black and isort to project
+# See https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html
+bc7b568fe0f925558718a71fdd42b5289a20cab8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,14 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install poetry
-        run: pip install poetry
-
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
           cache-dependency-path: "poetry.lock"
+
+      - name: Install poetry
+        run: pip install poetry
 
       - name: Install dependencies
         run: poetry install
@@ -39,19 +38,23 @@ jobs:
         run: make docker-up
 
       - name: Test
-        run: make test
+        # Wait for RabbitMQ to start.
+        run: sleep 10 && make test
 
   test-build-docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install poetry
-        run: pip install poetry
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: "3.10"
           cache: "pip"
           cache-dependency-path: "poetry.lock"
+
+      - name: Install poetry
+        run: pip install poetry
+
       - name: Install dependencies
         run: poetry install
-      - run: mkdocs build --verbose --clean --strict
+
+      - run: poetry run mkdocs build --verbose --clean --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,19 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+    # strategy:
+    #   matrix:
+    #     python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
+
+      - name: Run docker-compose stack for testing
+        run: make docker-up
+
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          # python-version: ${{ matrix.python-version }}
+          python-version: "^3.8"
           cache: "pip"
           cache-dependency-path: "poetry.lock"
 
@@ -33,9 +38,6 @@ jobs:
 
       - name: Lint
         run: make lint
-
-      - name: Run docker-compose stack for testing
-        run: make docker-up
 
       - name: Test
         # Wait for RabbitMQ to start.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # strategy:
-    #   matrix:
-    #     python-version: ["3.8", "3.9", "3.10"]
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
 
@@ -25,8 +25,8 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          # python-version: ${{ matrix.python-version }}
-          python-version: "^3.8"
+          python-version: ${{ matrix.python-version }}
+          # python-version: "^3.8"
           cache: "pip"
           cache-dependency-path: "poetry.lock"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,35 @@ env:
   POETRY_VIRTUALENVS_CREATE: false
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install poetry
+        run: pip install poetry
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "poetry.lock"
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Lint
+        run: make lint
+
+      - name: Run docker-compose stack for testing
+        run: make docker-up
+
+      - name: Test
+        run: make test
+
   test-build-docs:
     runs-on: ubuntu-latest
     steps:
@@ -21,8 +50,8 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: 3.x
-          cache: 'pip'
-          cache-dependency-path: 'poetry.lock'
+          cache: "pip"
+          cache-dependency-path: "poetry.lock"
       - name: Install dependencies
         run: poetry install
       - run: mkdocs build --verbose --clean --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,6 @@ on:
 env:
   POETRY_VIRTUALENVS_CREATE: false
 
-
 jobs:
   deploy:
     permissions:
@@ -16,14 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install poetry
-        run: pip install poetry
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.x
-          cache: 'pip'
-          cache-dependency-path: 'poetry.lock'
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "poetry.lock"
+
+      - name: Install poetry
+        run: pip install poetry
+
       - name: Install dependencies
         run: poetry install
+
       - name: Build and push docs
-        run: mkdocs gh-deploy --force
+        run: poetry run mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # Created by https://www.toptal.com/developers/gitignore/api/python,visualstudiocode,windows,macos,virtualenv,linux,vim,emacs
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,visualstudiocode,windows,macos,virtualenv,linux,vim,emacs
 
+/config.json
+
 ### Emacs ###
 # -*- mode: gitignore; -*-
 *~

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,7 @@
 extension-pkg-whitelist=
 
 # Specify a score threshold to be exceeded before program exits with error.
-fail-under=10.0
+fail-under=8.0
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,14 @@ lint-black:
 lint-pylint:
 	@poetry run pylint mognet
 
+lint-flake8:
+	@poetry run flake8
+
 lint-mypy:
 	@poetry run mypy mognet
 
 .PHONY: lint
-lint: lint-isort lint-black lint-pylint lint-mypy
+lint: lint-isort lint-black lint-flake8 lint-pylint lint-mypy
 
 .PHONY: docker-up
 docker-up:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+
+DOCKER_COMPOSE_FILE=.devcontainer/docker-compose.yaml
+
+.PHONY: format-black
+format-black:
+	@poetry run black .
+
+.PHONY: format-isort
+format-isort:
+	@poetry run isort .
+
+.PHONY: format
+format: format-isort format-black
+
+.PHONY: lint-isort
+lint-isort:
+	@poetry run isort --check .
+
+.PHONY: lint-black
+lint-black:
+	@poetry run black --check .
+
+lint-pylint:
+	@poetry run pylint mognet
+
+.PHONY: lint
+lint: lint-isort lint-black lint-pylint
+
+.PHONY: docker-up
+docker-up:
+	@docker-compose \
+		-f $(DOCKER_COMPOSE_FILE) \
+		up -d \
+		--remove-orphans
+
+.PHONY: test
+test:
+	@poetry run pytest test/

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,11 @@ lint-black:
 lint-pylint:
 	@poetry run pylint mognet
 
+lint-mypy:
+	@poetry run mypy mognet
+
 .PHONY: lint
-lint: lint-isort lint-black lint-pylint
+lint: lint-isort lint-black lint-pylint lint-mypy
 
 .PHONY: docker-up
 docker-up:

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,13 @@ lint: lint-isort lint-black lint-pylint
 docker-up:
 	@docker-compose \
 		-f $(DOCKER_COMPOSE_FILE) \
-		up -d \
-		--remove-orphans
+		up -d
+
+.PHONY: docker-down
+docker-down:
+	@docker-compose \
+		-f $(DOCKER_COMPOSE_FILE) \
+		down
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Mognet is a fast, simple framework to build distributed applications using task queues.
 
+[![PyPI](https://img.shields.io/pypi/v/mognet)](https://www.pypi.org/project/mognet)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mognet)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 ## Installing
 
 Mognet can be installed via pip, with:

--- a/demo/mognet_demo/api.py
+++ b/demo/mognet_demo/api.py
@@ -3,8 +3,8 @@ The API, responsible for receiving the files, submitting jobs, and getting their
 """
 
 import asyncio
-from contextlib import suppress
 import os
+from contextlib import suppress
 from typing import Optional
 from uuid import UUID, uuid4
 
@@ -18,13 +18,12 @@ from fastapi import (
     Response,
     UploadFile,
 )
-from pydantic import confloat
-
 from mognet_demo.config import DemoConfig
 from mognet_demo.models import Job, Upload, UploadJobResult
 from mognet_demo.mognet_app import app as mognet_app
 from mognet_demo.s3 import get_s3_client
 from mognet_demo.tasks import process_document_upload
+from pydantic import confloat
 
 app = FastAPI(
     title="Mognet Demo API",

--- a/demo/mognet_demo/config.py
+++ b/demo/mognet_demo/config.py
@@ -11,10 +11,10 @@ from typing import Optional
 from pydantic import BaseModel, BaseSettings
 
 from mognet import AppConfig
-from mognet.app.app_config import ResultBackendConfig, StateBackendConfig, BrokerConfig
+from mognet.app.app_config import BrokerConfig, ResultBackendConfig, StateBackendConfig
 from mognet.backend.backend_config import RedisResultBackendSettings
-from mognet.state.state_backend_config import RedisStateBackendSettings
 from mognet.broker.broker_config import AmqpBrokerSettings
+from mognet.state.state_backend_config import RedisStateBackendSettings
 
 
 class S3Config(BaseModel):

--- a/demo/mognet_demo/middleware/auto_shutdown.py
+++ b/demo/mognet_demo/middleware/auto_shutdown.py
@@ -16,11 +16,12 @@ It is therefore a good candidate for tasks like:
 import asyncio
 import logging
 from typing import TYPE_CHECKING, NoReturn, Optional
-from mognet.middleware.middleware import Middleware
+
 from mognet.cli.exceptions import GracefulShutdown
+from mognet.middleware.middleware import Middleware
 
 if TYPE_CHECKING:
-    from mognet import Result, Context, App
+    from mognet import App, Context, Result
 
 _log = logging.getLogger(__name__)
 

--- a/demo/mognet_demo/models.py
+++ b/demo/mognet_demo/models.py
@@ -3,8 +3,8 @@ Auxilliary models.
 """
 from typing import List, Optional
 from uuid import UUID
-from pydantic import BaseModel
 
+from pydantic import BaseModel
 
 from mognet.model.result_state import ResultState
 

--- a/demo/mognet_demo/mognet_app.py
+++ b/demo/mognet_demo/mognet_app.py
@@ -4,10 +4,10 @@ The Mognet app.
 It can be used both for submitting jobs and for launching the worker process via the CLI
 """
 
-from mognet import App
-
 from mognet_demo.config import DemoConfig
 from mognet_demo.middleware.auto_shutdown import AutoShutdownMiddleware
+
+from mognet import App
 
 _mognet_config = DemoConfig.instance().mognet
 

--- a/demo/mognet_demo/mognet_app.py
+++ b/demo/mognet_demo/mognet_app.py
@@ -5,7 +5,6 @@ It can be used both for submitting jobs and for launching the worker process via
 """
 
 from mognet_demo.config import DemoConfig
-from mognet_demo.middleware.auto_shutdown import AutoShutdownMiddleware
 
 from mognet import App
 

--- a/demo/mognet_demo/s3.py
+++ b/demo/mognet_demo/s3.py
@@ -5,10 +5,8 @@ Simple communication to an S3 backend.
 from contextlib import asynccontextmanager
 
 from aiobotocore.session import get_session
-
-from mognet_demo.config import DemoConfig
-
 from botocore.exceptions import ClientError
+from mognet_demo.config import DemoConfig
 
 
 @asynccontextmanager

--- a/demo/mognet_demo/tasks.py
+++ b/demo/mognet_demo/tasks.py
@@ -7,14 +7,14 @@ import logging
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Set, List
+from typing import List, Set
 from uuid import uuid4
-
-from mognet import Context, Request, task
 
 from mognet_demo.config import DemoConfig
 from mognet_demo.models import Document, Upload, UploadResult
 from mognet_demo.s3 import get_s3_client
+
+from mognet import Context, Request, task
 
 _log = logging.getLogger(__name__)
 

--- a/demo/test/conftest.py
+++ b/demo/test/conftest.py
@@ -1,10 +1,8 @@
 import pytest
-
+from mognet_demo.config import DemoConfig
+from mognet_demo.mognet_app import app
 
 from mognet.testing.pytest_integration import create_app_fixture
-from mognet_demo.config import DemoConfig
-
-from mognet_demo.mognet_app import app
 
 
 @pytest.fixture

--- a/demo/test/test_api.py
+++ b/demo/test/test_api.py
@@ -1,9 +1,10 @@
 import time
-import requests
 from pathlib import Path
-from mognet_demo.models import Job, UploadJobResult
-from mognet.model.result_state import READY_STATES, SUCCESS_STATES
 
+import requests
+from mognet_demo.models import Job, UploadJobResult
+
+from mognet.model.result_state import READY_STATES, SUCCESS_STATES
 
 _cwd = Path(__file__).parent
 

--- a/demo/test/test_worker_task.py
+++ b/demo/test/test_worker_task.py
@@ -9,12 +9,12 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from mognet import App, Request
 from mognet_demo.config import DemoConfig
 from mognet_demo.models import Upload, UploadResult
 from mognet_demo.s3 import get_s3_client
 from mognet_demo.tasks import InvalidFile
 
+from mognet import App, Request
 
 _cwd = Path(__file__).parent
 

--- a/mognet/__init__.py
+++ b/mognet/__init__.py
@@ -1,11 +1,11 @@
 from .app.app import App
 from .app.app_config import AppConfig
 from .context.context import Context
-from .model.result import Result
-from .primitives.request import Request
 from .decorators.task_decorator import task
-from .model.result_state import ResultState
 from .middleware.middleware import Middleware
+from .model.result import Result
+from .model.result_state import ResultState
+from .primitives.request import Request
 
 __all__ = [
     "App",

--- a/mognet/app/app.py
+++ b/mognet/app/app.py
@@ -22,6 +22,7 @@ from typing import (
 )
 
 from aio_pika.tools import shield
+
 from mognet.backend.base_result_backend import BaseResultBackend
 from mognet.backend.redis_result_backend import RedisResultBackend
 from mognet.broker.amqp_broker import AmqpBroker
@@ -46,9 +47,9 @@ from mognet.tools.kwargs_repr import format_kwargs_repr
 from mognet.worker.worker import MessageCancellationAction, Worker
 
 if sys.version_info >= (3, 10):
-    from typing import ParamSpec, Concatenate
+    from typing import Concatenate, ParamSpec
 else:
-    from typing_extensions import ParamSpec, Concatenate
+    from typing_extensions import Concatenate, ParamSpec
 
 
 if TYPE_CHECKING:

--- a/mognet/app/app_config.py
+++ b/mognet/app/app_config.py
@@ -19,10 +19,10 @@ class Queues(BaseModel):
     exclude: Set[str] = Field(default_factory=set)
 
     @property
-    def is_valid(self):
+    def is_valid(self) -> bool:
         return not (len(self.include) > 0 and len(self.exclude) > 0)
 
-    def ensure_valid(self):
+    def ensure_valid(self) -> None:
         if not self.is_valid:
             raise ValueError(
                 "Cannot specify both 'include' and 'exclude'. Choose either or none."

--- a/mognet/app/app_config.py
+++ b/mognet/app/app_config.py
@@ -2,11 +2,12 @@ import os
 import socket
 from typing import Any, Dict, List, Optional, Set
 
+from pydantic.fields import Field
+from pydantic.main import BaseModel
+
 from mognet.backend.backend_config import ResultBackendConfig
 from mognet.broker.broker_config import BrokerConfig
 from mognet.state.state_backend_config import StateBackendConfig
-from pydantic.fields import Field
-from pydantic.main import BaseModel
 
 
 def _default_node_id() -> str:

--- a/mognet/backend/backend_config.py
+++ b/mognet/backend/backend_config.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from enum import Enum
 from typing import Optional
+
 from pydantic import BaseModel
 
 

--- a/mognet/backend/base_result_backend.py
+++ b/mognet/backend/base_result_backend.py
@@ -1,15 +1,7 @@
 import asyncio
 from abc import ABCMeta, abstractmethod
 from datetime import timedelta
-from typing import (
-    Any,
-    AsyncGenerator,
-    Dict,
-    List,
-    Optional,
-    Protocol,
-    Union,
-)
+from typing import Any, AsyncGenerator, Dict, List, Optional, Protocol, Union
 from uuid import UUID
 
 from mognet.backend.backend_config import ResultBackendConfig

--- a/mognet/backend/base_result_backend.py
+++ b/mognet/backend/base_result_backend.py
@@ -3,17 +3,7 @@ from __future__ import annotations
 import asyncio
 from abc import ABCMeta, abstractmethod
 from datetime import timedelta
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AsyncGenerator,
-    AsyncIterable,
-    Dict,
-    List,
-    Optional,
-    Protocol,
-    Union,
-)
+from typing import Any, AsyncIterable, Dict, List, Optional, Protocol
 from uuid import UUID
 
 from mognet.backend.backend_config import ResultBackendConfig

--- a/mognet/backend/memory_result_backend.py
+++ b/mognet/backend/memory_result_backend.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional, Set
 from uuid import UUID
 
 from mognet.backend.backend_config import ResultBackendConfig

--- a/mognet/backend/memory_result_backend.py
+++ b/mognet/backend/memory_result_backend.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from typing import Any, AsyncGenerator, Dict, List, Optional, Set, Tuple
 from uuid import UUID
+
 from mognet.backend.backend_config import ResultBackendConfig
 from mognet.backend.base_result_backend import AppParameters, BaseResultBackend
 from mognet.exceptions.result_exceptions import ResultValueLost

--- a/mognet/backend/redis_result_backend.py
+++ b/mognet/backend/redis_result_backend.py
@@ -5,6 +5,7 @@ import functools
 import gzip
 import json
 import logging
+import sys
 from asyncio import shield
 from datetime import timedelta
 from typing import (
@@ -30,7 +31,6 @@ from uuid import UUID
 from pydantic.tools import parse_raw_as
 from redis.asyncio import from_url
 from redis.exceptions import ConnectionError, TimeoutError
-from typing_extensions import TypeAlias
 
 from mognet.backend.backend_config import Encoding, ResultBackendConfig
 from mognet.backend.base_result_backend import AppParameters, BaseResultBackend
@@ -40,15 +40,18 @@ from mognet.model.result import Result, ResultValueHolder
 from mognet.model.result_state import READY_STATES, ResultState
 from mognet.tools.urls import censor_credentials
 
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
+
 if TYPE_CHECKING:
     from redis.asyncio import Redis  # noqa: F401
 
 _log = logging.getLogger(__name__)
 
 
-_EncodedHSetPayload: TypeAlias = Mapping[
-    Union[str, bytes], Union[bytes, float, int, str]
-]
+_EncodedHSetPayload = Mapping[Union[str, bytes], Union[bytes, float, int, str]]
 
 _F = TypeVar("_F", bound=Callable[..., Awaitable[Any]])
 _Redis: TypeAlias = "Redis[Any]"

--- a/mognet/backend/redis_result_backend.py
+++ b/mognet/backend/redis_result_backend.py
@@ -8,6 +8,7 @@ import logging
 from asyncio import shield
 from datetime import timedelta
 from typing import (
+    TYPE_CHECKING,
     Any,
     AnyStr,
     AsyncIterable,
@@ -27,7 +28,7 @@ from typing import (
 from uuid import UUID
 
 from pydantic.tools import parse_raw_as
-from redis.asyncio import Redis, from_url
+from redis.asyncio import from_url
 from redis.exceptions import ConnectionError, TimeoutError
 from typing_extensions import TypeAlias
 
@@ -38,6 +39,9 @@ from mognet.exceptions.result_exceptions import ResultValueLost
 from mognet.model.result import Result, ResultValueHolder
 from mognet.model.result_state import READY_STATES, ResultState
 from mognet.tools.urls import censor_credentials
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis  # noqa: F401
 
 _log = logging.getLogger(__name__)
 

--- a/mognet/backend/redis_result_backend.py
+++ b/mognet/backend/redis_result_backend.py
@@ -6,14 +6,30 @@ import gzip
 import json
 import logging
 from asyncio import shield
-from typing_extensions import TypeAlias
 from datetime import timedelta
-from typing import Any, AnyStr, Dict, Iterable, List, Mapping, Optional, Set, Union
+from typing import (
+    Any,
+    AnyStr,
+    AsyncIterable,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 from uuid import UUID
 
 from pydantic.tools import parse_raw_as
 from redis.asyncio import Redis, from_url
 from redis.exceptions import ConnectionError, TimeoutError
+from typing_extensions import TypeAlias
 
 from mognet.backend.backend_config import Encoding, ResultBackendConfig
 from mognet.backend.base_result_backend import AppParameters, BaseResultBackend
@@ -30,10 +46,13 @@ _EncodedHSetPayload: TypeAlias = Mapping[
     Union[str, bytes], Union[bytes, float, int, str]
 ]
 
+_F = TypeVar("_F", bound=Callable[..., Awaitable[Any]])
+_Redis: TypeAlias = "Redis[Any]"
 
-def _retry(func):
+
+def _retry(func: _F) -> _F:
     @functools.wraps(func)
-    async def retry_wrapper(self: RedisResultBackend, *args, **kwargs):
+    async def retry_wrapper(self: RedisResultBackend, *args: Any, **kwargs: Any) -> Any:
         last_err = None
 
         sleep_s = 1.0
@@ -66,7 +85,7 @@ def _retry(func):
         if last_err is not None:
             raise last_err
 
-    return retry_wrapper
+    return cast(_F, retry_wrapper)
 
 
 class RedisResultBackend(BaseResultBackend):
@@ -78,11 +97,11 @@ class RedisResultBackend(BaseResultBackend):
         super().__init__(config, app)
 
         self._url = config.redis.url
-        self.__redis = None
+        self.__redis: Optional[_Redis] = None
         self._connected = False
 
         # Holds references to tasks which are spawned by .wait()
-        self._waiters: List[asyncio.Future] = []
+        self._waiters: List["asyncio.Future[Any]"] = []
 
         # Attributes for @_retry
         self._retry_connect_attempts = self.config.redis.retry_connect_attempts
@@ -90,14 +109,14 @@ class RedisResultBackend(BaseResultBackend):
         self._retry_lock = asyncio.Lock()
 
     @property
-    def _redis(self) -> Redis:
+    def _redis(self) -> _Redis:
         if self.__redis is None:
             raise NotConnected
 
         return self.__redis
 
     @_retry
-    async def get(self, result_id: UUID) -> Optional[Result]:
+    async def get(self, result_id: UUID) -> Optional[Result[Any]]:
         obj_key = self._format_key(result_id)
 
         async with self._redis.pipeline(transaction=True) as pip:
@@ -114,7 +133,7 @@ class RedisResultBackend(BaseResultBackend):
         return self._decode_result(value)
 
     @_retry
-    async def get_or_create(self, result_id: UUID) -> Result:
+    async def get_or_create(self, result_id: UUID) -> Result[Any]:
         """
         Gets a result, or creates one if it doesn't exist.
         """
@@ -173,7 +192,7 @@ class RedisResultBackend(BaseResultBackend):
         return ResultValueHolder.parse_raw(contents, content_type="application/json")
 
     @_retry
-    async def set(self, result_id: UUID, result: Result):
+    async def set(self, result_id: UUID, result: Result[Any]) -> Any:
         key = self._format_key(result_id)
 
         async with self._redis.pipeline(transaction=True) as pip:
@@ -187,7 +206,7 @@ class RedisResultBackend(BaseResultBackend):
 
             await shield(pip.execute())
 
-    def _format_key(self, result_id: UUID, subkey: str = None) -> str:
+    def _format_key(self, result_id: UUID, subkey: Optional[str] = None) -> str:
         key = f"{self.app.name}.mognet.result.{str(result_id)}"
 
         if subkey:
@@ -200,7 +219,7 @@ class RedisResultBackend(BaseResultBackend):
         return key
 
     @_retry
-    async def add_children(self, result_id: UUID, *children: UUID):
+    async def add_children(self, result_id: UUID, *children: UUID) -> None:
         if not children:
             return
 
@@ -232,7 +251,7 @@ class RedisResultBackend(BaseResultBackend):
 
         return self._decode_result_value(contents)
 
-    async def set_value(self, result_id: UUID, value: ResultValueHolder):
+    async def set_value(self, result_id: UUID, value: ResultValueHolder) -> None:
         value_key = self._format_key(result_id, "value")
 
         encoded = self._encode_result_value(value)
@@ -246,7 +265,7 @@ class RedisResultBackend(BaseResultBackend):
 
             await shield(pip.execute())
 
-    async def delete(self, result_id: UUID, include_children: bool = True):
+    async def delete(self, result_id: UUID, include_children: bool = True) -> None:
         if include_children:
             async for child_id in self.iterate_children_ids(result_id):
                 await self.delete(child_id, include_children=True)
@@ -260,7 +279,7 @@ class RedisResultBackend(BaseResultBackend):
 
     async def set_ttl(
         self, result_id: UUID, ttl: timedelta, include_children: bool = True
-    ):
+    ) -> None:
         if include_children:
             async for child_id in self.iterate_children_ids(result_id):
                 await self.set_ttl(child_id, ttl, include_children=True)
@@ -275,7 +294,7 @@ class RedisResultBackend(BaseResultBackend):
         await shield(self._redis.expire(value_key, ttl))
         await shield(self._redis.expire(metadata_key, ttl))
 
-    async def connect(self):
+    async def connect(self) -> None:
         if self._connected:
             return
 
@@ -283,7 +302,7 @@ class RedisResultBackend(BaseResultBackend):
 
         await self._connect()
 
-    async def close(self):
+    async def close(self) -> None:
         self._connected = False
 
         await self._close_waiters()
@@ -297,7 +316,7 @@ class RedisResultBackend(BaseResultBackend):
 
     async def iterate_children_ids(
         self, parent_result_id: UUID, *, count: Optional[int] = None
-    ):
+    ) -> AsyncIterable[UUID]:
         children_key = self._format_key(parent_result_id, "children")
 
         raw_child_id: bytes
@@ -307,7 +326,7 @@ class RedisResultBackend(BaseResultBackend):
 
     async def iterate_children(
         self, parent_result_id: UUID, *, count: Optional[int] = None
-    ):
+    ) -> AsyncIterable[Result[Any]]:
         async for child_id in self.iterate_children_ids(parent_result_id, count=count):
             child = await self.get(child_id)
 
@@ -317,8 +336,8 @@ class RedisResultBackend(BaseResultBackend):
     @_retry
     async def wait(
         self, result_id: UUID, timeout: Optional[float] = None, poll: float = 1
-    ) -> Result:
-        async def waiter():
+    ) -> Result[Any]:
+        async def waiter() -> Result[Any]:
             key = self._format_key(result_id=result_id)
 
             # Type def for the state key. It can (but shouldn't)
@@ -328,7 +347,7 @@ class RedisResultBackend(BaseResultBackend):
             while True:
                 raw_state = await shield(self._redis.hget(key, "state")) or b"null"
 
-                state = parse_raw_as(t, raw_state)
+                state = parse_raw_as(cast(Type[Optional[ResultState]], t), raw_state)
 
                 if state is None:
                     raise ResultValueLost(result_id)
@@ -379,18 +398,18 @@ class RedisResultBackend(BaseResultBackend):
 
             await shield(pip.execute())
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"RedisResultBackend(url={censor_credentials(self._url)!r})"
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> RedisResultBackend:
         await self.connect()
 
         return self
 
-    async def __aexit__(self, *args, **kwargs):
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
         await self.close()
 
-    async def _close_waiters(self):
+    async def _close_waiters(self) -> None:
         """
         Cancel any wait loop we have running.
         """
@@ -407,9 +426,9 @@ class RedisResultBackend(BaseResultBackend):
             except Exception as exc:  # pylint: disable=broad-except
                 _log.debug("Error on waiter task %r", waiter_task, exc_info=exc)
 
-    async def _create_redis(self):
+    async def _create_redis(self) -> _Redis:
         _log.debug("Creating Redis connection")
-        redis: Redis = await from_url(
+        redis: _Redis = await from_url(
             self._url,
             max_connections=self.config.redis.max_connections,
         )
@@ -417,13 +436,13 @@ class RedisResultBackend(BaseResultBackend):
         return redis
 
     @_retry
-    async def _connect(self):
+    async def _connect(self) -> None:
         if self.__redis is None:
             self.__redis = await self._create_redis()
 
         await shield(self._redis.ping())
 
-    async def _disconnect(self):
+    async def _disconnect(self) -> None:
         redis = self.__redis
 
         if redis is not None:
@@ -431,14 +450,14 @@ class RedisResultBackend(BaseResultBackend):
             _log.debug("Closing Redis connection")
             await redis.close()
 
-    def _decode_result(self, json_dict: Dict[bytes, bytes]) -> Result:
+    def _decode_result(self, json_dict: Dict[bytes, bytes]) -> Result[Any]:
         # Load the dict of JSON values first; then update it with overrides.
         value = _decode_json_dict(json_dict)
         return Result(self, **value)
 
 
-def _encode_result(result: Result) -> _EncodedHSetPayload:
-    json_dict: dict = json.loads(result.json())
+def _encode_result(result: Result[Any]) -> _EncodedHSetPayload:
+    json_dict: Dict[str, Any] = json.loads(result.json())
     return _dict_to_json_dict(json_dict)
 
 
@@ -452,7 +471,7 @@ def _encode_children(children: Iterable[UUID]) -> Set[bytes]:
     return {c.bytes for c in children}
 
 
-def _decode_json_dict(json_dict: Dict[bytes, AnyStr]) -> dict:
+def _decode_json_dict(json_dict: Dict[bytes, AnyStr]) -> Dict[str, Any]:
     """
     Decode a dict coming from hgetall/hmget, which is encoded with bytes as keys
     and bytes or str as values, containing JSON values.

--- a/mognet/broker/amqp_broker.py
+++ b/mognet/broker/amqp_broker.py
@@ -23,6 +23,8 @@ from aio_pika.exchange import Exchange, ExchangeType
 from aio_pika.message import IncomingMessage, Message
 from aio_pika.queue import Queue
 from aiormq.exceptions import AMQPChannelError, ChannelInvalidStateError
+from pydantic.fields import PrivateAttr
+
 from mognet.broker.base_broker import (
     BaseBroker,
     IncomingMessagePayload,
@@ -36,7 +38,6 @@ from mognet.model.queue_stats import QueueStats
 from mognet.primitives.queries import QueryResponseMessage
 from mognet.tools.retries import retryableasyncmethod
 from mognet.tools.urls import censor_credentials
-from pydantic.fields import PrivateAttr
 
 _log = logging.getLogger(__name__)
 

--- a/mognet/broker/amqp_broker.py
+++ b/mognet/broker/amqp_broker.py
@@ -130,7 +130,7 @@ class AmqpBroker(BaseBroker):
         self.config = config
 
         self._task_queues = {}
-        self._control_queue = None
+        self._control_queue: Optional[Queue] = None
 
         # Lock to prevent duplicate queue declaration
         self._lock = Lock()
@@ -494,6 +494,8 @@ class AmqpBroker(BaseBroker):
                     await self._control_queue.bind(self._control_exchange)
 
                     _log.debug("Prepared control queue=%r", self._control_queue.name)
+
+        assert self._control_queue is not None
 
         return self._control_queue
 

--- a/mognet/broker/amqp_broker.py
+++ b/mognet/broker/amqp_broker.py
@@ -9,7 +9,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
-    Awaitable,
     Callable,
     Coroutine,
     Dict,

--- a/mognet/broker/base_broker.py
+++ b/mognet/broker/base_broker.py
@@ -1,14 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import (
-    Any,
-    AsyncGenerator,
-    Awaitable,
-    Callable,
-    Coroutine,
-    Dict,
-    List,
-    Optional,
-)
+from typing import Any, AsyncGenerator, Callable, Coroutine, Optional
 
 from pydantic.main import BaseModel
 

--- a/mognet/broker/base_broker.py
+++ b/mognet/broker/base_broker.py
@@ -1,5 +1,14 @@
 from abc import ABCMeta, abstractmethod
-from typing import AsyncGenerator, Awaitable, Callable, List, Optional
+from typing import (
+    Any,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+)
 
 from pydantic.main import BaseModel
 
@@ -10,7 +19,7 @@ from mognet.primitives.queries import QueryResponseMessage
 class MessagePayload(BaseModel):
     id: str
     kind: str
-    payload: dict
+    payload: Any
 
     priority: int = 5
 
@@ -36,11 +45,11 @@ class TaskQueue(BaseModel):
 
 class BaseBroker(metaclass=ABCMeta):
     @abstractmethod
-    async def send_task_message(self, queue: str, payload: MessagePayload):
+    async def send_task_message(self, queue: str, payload: MessagePayload) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    async def send_control_message(self, payload: MessagePayload):
+    async def send_control_message(self, payload: MessagePayload) -> None:
         raise NotImplementedError
 
     @abstractmethod
@@ -51,30 +60,30 @@ class BaseBroker(metaclass=ABCMeta):
     def consume_control_queue(self) -> AsyncGenerator[IncomingMessagePayload, None]:
         raise NotImplementedError
 
-    async def __aenter__(self):
+    async def __aenter__(self):  # type: ignore
         return self
 
-    async def __aexit__(self, *args, **kwargs):
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
         return None
 
-    async def connect(self):
+    async def connect(self) -> None:
         pass
 
-    async def close(self):
+    async def close(self) -> None:
         pass
 
     @abstractmethod
-    async def setup_task_queue(self, queue: TaskQueue):
+    async def setup_task_queue(self, queue: TaskQueue) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    async def setup_control_queue(self):
+    async def setup_control_queue(self) -> None:
         raise NotImplementedError
 
-    async def set_task_prefetch(self, prefetch: int):
+    async def set_task_prefetch(self, prefetch: int) -> None:
         pass
 
-    async def set_control_prefetch(self, prefetch: int):
+    async def set_control_prefetch(self, prefetch: int) -> None:
         pass
 
     @abstractmethod
@@ -84,7 +93,9 @@ class BaseBroker(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    async def send_reply(self, message: IncomingMessagePayload, reply: MessagePayload):
+    async def send_reply(
+        self, message: IncomingMessagePayload, reply: MessagePayload
+    ) -> None:
         raise NotImplementedError
 
     @abstractmethod
@@ -96,8 +107,8 @@ class BaseBroker(metaclass=ABCMeta):
         raise NotImplementedError
 
     def add_connection_failed_callback(
-        self, cb: Callable[[Optional[BaseException]], Awaitable]
-    ):
+        self, cb: Callable[[Optional[BaseException]], Coroutine[Any, Any, Any]]
+    ) -> None:
         pass
 
     @abstractmethod

--- a/mognet/broker/base_broker.py
+++ b/mognet/broker/base_broker.py
@@ -1,9 +1,10 @@
 from abc import ABCMeta, abstractmethod
-from mognet.model.queue_stats import QueueStats
-from mognet.primitives.queries import QueryResponseMessage
 from typing import AsyncGenerator, Awaitable, Callable, List, Optional
 
 from pydantic.main import BaseModel
+
+from mognet.model.queue_stats import QueueStats
+from mognet.primitives.queries import QueryResponseMessage
 
 
 class MessagePayload(BaseModel):

--- a/mognet/broker/broker_config.py
+++ b/mognet/broker/broker_config.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from pydantic import BaseModel
 
 

--- a/mognet/broker/broker_config.py
+++ b/mognet/broker/broker_config.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
 

--- a/mognet/broker/memory_broker.py
+++ b/mognet/broker/memory_broker.py
@@ -1,6 +1,6 @@
 import asyncio
 from asyncio import Queue
-from typing import AsyncGenerator, Dict
+from typing import Any, AsyncGenerator, Dict
 from uuid import uuid4
 
 from pydantic.fields import PrivateAttr
@@ -18,9 +18,11 @@ from mognet.primitives.queries import QueryResponseMessage
 class _InMemoryIncomingMessagePayload(IncomingMessagePayload):
 
     _broker: "InMemoryBroker" = PrivateAttr()
-    _queue: Queue = PrivateAttr()
+    _queue: "Queue[MessagePayload]" = PrivateAttr()
 
-    def __init__(self, broker: "InMemoryBroker", queue: Queue, **data):
+    def __init__(
+        self, broker: "InMemoryBroker", queue: "Queue[MessagePayload]", **data: Any
+    ) -> None:
         super().__init__(**data)
 
         self._broker = broker
@@ -50,10 +52,10 @@ class InMemoryBroker(BaseBroker):
 
         self._callback_queues: Dict[str, "Queue[MessagePayload]"] = {}
 
-    async def send_task_message(self, queue: str, payload: MessagePayload):
+    async def send_task_message(self, queue: str, payload: MessagePayload) -> None:
         await self._task_queues[queue].put(payload)
 
-    async def send_control_message(self, payload: MessagePayload):
+    async def send_control_message(self, payload: MessagePayload) -> None:
         await self._control_queue.put(payload)
 
     async def consume_tasks(
@@ -92,27 +94,27 @@ class InMemoryBroker(BaseBroker):
                 reply_to=None,
             )
 
-    async def setup_task_queue(self, queue: TaskQueue):
+    async def setup_task_queue(self, queue: TaskQueue) -> None:
         self._task_queues[queue.name] = Queue()
 
-    async def setup_control_queue(self):
+    async def setup_control_queue(self) -> None:
         pass
 
-    def _update_task_event(self):
+    def _update_task_event(self) -> None:
         if self._unacked_task_count < self._task_prefetch:
             self._task_event.set()
         else:
             self._task_event.clear()
 
-    async def ack_task(self):
+    async def ack_task(self) -> None:
         self._unacked_task_count = max(0, self._unacked_task_count - 1)
         self._update_task_event()
 
-    async def set_task_prefetch(self, prefetch: int):
+    async def set_task_prefetch(self, prefetch: int) -> None:
         self._task_prefetch = prefetch
         self._update_task_event()
 
-    async def set_control_prefetch(self, prefetch: int):
+    async def set_control_prefetch(self, prefetch: int) -> None:
         self._control_prefetch = prefetch
 
     async def send_query_message(
@@ -140,7 +142,9 @@ class InMemoryBroker(BaseBroker):
         finally:
             self._callback_queues.pop(queue_id, None)
 
-    async def send_reply(self, message: IncomingMessagePayload, reply: MessagePayload):
+    async def send_reply(
+        self, message: IncomingMessagePayload, reply: MessagePayload
+    ) -> None:
         if not message.reply_to:
             raise ValueError("No one to send reply to")
 
@@ -168,7 +172,7 @@ class InMemoryBroker(BaseBroker):
         )
 
 
-def _purge_queue(q: Queue) -> int:
+def _purge_queue(q: Queue[Any]) -> int:
     old_size = q.qsize()
 
     while not q.empty():

--- a/mognet/broker/memory_broker.py
+++ b/mognet/broker/memory_broker.py
@@ -1,8 +1,10 @@
-from asyncio import Queue
 import asyncio
+from asyncio import Queue
+from typing import AsyncGenerator, Dict
 from uuid import uuid4
 
 from pydantic.fields import PrivateAttr
+
 from mognet.broker.base_broker import (
     BaseBroker,
     IncomingMessagePayload,
@@ -11,7 +13,6 @@ from mognet.broker.base_broker import (
 )
 from mognet.model.queue_stats import QueueStats
 from mognet.primitives.queries import QueryResponseMessage
-from typing import AsyncGenerator, Dict
 
 
 class _InMemoryIncomingMessagePayload(IncomingMessagePayload):

--- a/mognet/cli/main.py
+++ b/mognet/cli/main.py
@@ -6,13 +6,10 @@ from typing import TYPE_CHECKING
 
 import typer
 
+from mognet import App
 from mognet.cli import nodes, queues, run, tasks
 from mognet.cli.cli_state import state
 from mognet.cli.models import LogLevel
-
-if TYPE_CHECKING:
-    from mognet import App
-
 
 main = typer.Typer(name="mognet")
 
@@ -34,7 +31,7 @@ def _get_app(app_pointer: str) -> "App":
 
     app = getattr(app_module, app_var_name or "app", None)
 
-    if app is None:
+    if not isinstance(app, App):
         raise _AppNotFound(
             f"Could not find an app on {app_module_name!r}. Expected to find an attribute named {app_var_name!r}\n"
             f"You can specify a different attribute after a ':'.\n"
@@ -51,7 +48,7 @@ def callback(
     log_format: str = typer.Option(
         "%(asctime)s:%(name)s:%(levelname)s:%(message)s", metavar="log-format"
     ),
-):
+) -> None:
     """Mognet CLI"""
 
     logging.basicConfig(

--- a/mognet/cli/main.py
+++ b/mognet/cli/main.py
@@ -2,7 +2,6 @@ import importlib
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING
 
 import typer
 
@@ -43,9 +42,9 @@ def _get_app(app_pointer: str) -> "App":
 
 @main.callback()
 def callback(
-    app: str = typer.Argument(..., help="App module to import"),
-    log_level: LogLevel = typer.Option("INFO", metavar="log-level"),
-    log_format: str = typer.Option(
+    app: str = typer.Argument(..., help="App module to import"),  # noqa: B008
+    log_level: LogLevel = typer.Option("INFO", metavar="log-level"),  # noqa: B008
+    log_format: str = typer.Option(  # noqa: B008
         "%(asctime)s:%(name)s:%(levelname)s:%(message)s", metavar="log-format"
     ),
 ) -> None:

--- a/mognet/cli/main.py
+++ b/mognet/cli/main.py
@@ -5,6 +5,7 @@ import sys
 from typing import TYPE_CHECKING
 
 import typer
+
 from mognet.cli import nodes, queues, run, tasks
 from mognet.cli.cli_state import state
 from mognet.cli.models import LogLevel

--- a/mognet/cli/nodes.py
+++ b/mognet/cli/nodes.py
@@ -4,13 +4,14 @@ from typing import List, Optional
 
 import tabulate
 import typer
+from pydantic import BaseModel, Field
+
 from mognet.cli.cli_state import state
 from mognet.cli.models import OutputFormat
 from mognet.cli.run_in_loop import run_in_loop
 from mognet.model.result import Result
 from mognet.primitives.queries import StatusResponseMessage
 from mognet.tools.dates import now_utc
-from pydantic import BaseModel, Field
 
 group = typer.Typer()
 

--- a/mognet/cli/nodes.py
+++ b/mognet/cli/nodes.py
@@ -1,6 +1,6 @@
 import asyncio
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import tabulate
 import typer
@@ -35,14 +35,14 @@ async def status(
         30,
         help="Timeout for querying nodes",
     ),
-):
+) -> None:
     """Query each node for their status"""
 
     async with state["app_instance"] as app:
         while True:
             each_node_status: List[StatusResponseMessage] = []
 
-            async def read_status():
+            async def read_status() -> None:
                 async for node_status in app.get_current_status_of_nodes():
                     each_node_status.append(node_status)
 
@@ -116,6 +116,6 @@ async def status(
 class _CliStatusReport(BaseModel):
     class NodeStatus(BaseModel):
         node_id: str
-        running_requests: List[Result]
+        running_requests: List[Result[Any]]
 
     node_status: List[NodeStatus] = Field(default_factory=list)

--- a/mognet/cli/nodes.py
+++ b/mognet/cli/nodes.py
@@ -19,19 +19,21 @@ group = typer.Typer()
 @group.command("status")
 @run_in_loop
 async def status(
-    format: OutputFormat = typer.Option(OutputFormat.TEXT, metavar="format"),
-    text_label_format: str = typer.Option(
+    format: OutputFormat = typer.Option(  # noqa: B008
+        OutputFormat.TEXT, metavar="format"
+    ),  # noqa: B008
+    text_label_format: str = typer.Option(  # noqa: B008
         "{name}(id={id!r}, state={state!r})",
         metavar="text-label-format",
         help="Label format for text format",
     ),
-    json_indent: int = typer.Option(2, metavar="json-indent"),
-    poll: Optional[int] = typer.Option(
+    json_indent: int = typer.Option(2, metavar="json-indent"),  # noqa: B008
+    poll: Optional[int] = typer.Option(  # noqa: B008
         None,
         metavar="poll",
         help="Polling interval, in seconds (default=None)",
     ),
-    timeout: int = typer.Option(
+    timeout: int = typer.Option(  # noqa: B008
         30,
         help="Timeout for querying nodes",
     ),
@@ -42,12 +44,13 @@ async def status(
         while True:
             each_node_status: List[StatusResponseMessage] = []
 
-            async def read_status() -> None:
-                async for node_status in app.get_current_status_of_nodes():
-                    each_node_status.append(node_status)
+            async def read_status() -> List[StatusResponseMessage]:
+                return [ns async for ns in app.get_current_status_of_nodes()]
 
             try:
-                await asyncio.wait_for(read_status(), timeout=timeout)
+                each_node_status.extend(
+                    await asyncio.wait_for(read_status(), timeout=timeout)
+                )
             except asyncio.TimeoutError:
                 pass
 

--- a/mognet/cli/queues.py
+++ b/mognet/cli/queues.py
@@ -10,7 +10,7 @@ group = typer.Typer()
 
 @group.command("purge")
 @run_in_loop
-async def purge(force: bool = typer.Option(False)):
+async def purge(force: bool = typer.Option(False)) -> None:
     """Purge task and control queues"""
 
     if not force:

--- a/mognet/cli/queues.py
+++ b/mognet/cli/queues.py
@@ -1,5 +1,3 @@
-import logging
-
 import typer
 
 from mognet.cli.cli_state import state
@@ -10,7 +8,9 @@ group = typer.Typer()
 
 @group.command("purge")
 @run_in_loop
-async def purge(force: bool = typer.Option(False)) -> None:
+async def purge(
+    force: bool = typer.Option(False),  # noqa: B008
+) -> None:
     """Purge task and control queues"""
 
     if not force:

--- a/mognet/cli/queues.py
+++ b/mognet/cli/queues.py
@@ -1,8 +1,9 @@
 import logging
 
 import typer
-from mognet.cli.run_in_loop import run_in_loop
+
 from mognet.cli.cli_state import state
+from mognet.cli.run_in_loop import run_in_loop
 
 group = typer.Typer()
 

--- a/mognet/cli/run.py
+++ b/mognet/cli/run.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from asyncio import AbstractEventLoop
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import aiorun
 import typer
@@ -26,7 +26,7 @@ def run(
         metavar="exclude-queues",
         help="Comma-separated list of the ONLY queues to NOT listen on.",
     ),
-):
+) -> int:
     """Run the app"""
 
     app = state["app_instance"]
@@ -42,17 +42,19 @@ def run(
 
     queues.ensure_valid()
 
-    async def start():
+    async def start() -> None:
         async with app:
             await app.start()
 
-    async def stop(_: AbstractEventLoop):
+    async def stop(_: AbstractEventLoop) -> None:
         _log.info("Going to close app as part of a shut down")
         await app.close()
 
     pending_exception_to_raise: BaseException = SystemExit(0)
 
-    def custom_exception_handler(loop: AbstractEventLoop, context: dict):
+    def custom_exception_handler(
+        loop: AbstractEventLoop, context: Dict[Any, Any]
+    ) -> None:
         """See: https://docs.python.org/3/library/asyncio-eventloop.html#error-handling-api"""
 
         nonlocal pending_exception_to_raise

--- a/mognet/cli/run.py
+++ b/mognet/cli/run.py
@@ -50,7 +50,7 @@ def run(
         _log.info("Going to close app as part of a shut down")
         await app.close()
 
-    pending_exception_to_raise = SystemExit(0)
+    pending_exception_to_raise: BaseException = SystemExit(0)
 
     def custom_exception_handler(loop: AbstractEventLoop, context: dict):
         """See: https://docs.python.org/3/library/asyncio-eventloop.html#error-handling-api"""

--- a/mognet/cli/run.py
+++ b/mognet/cli/run.py
@@ -1,9 +1,11 @@
-import aiorun
-from asyncio import AbstractEventLoop
 import asyncio
 import logging
+from asyncio import AbstractEventLoop
 from typing import Optional
+
+import aiorun
 import typer
+
 from mognet.cli.cli_state import state
 from mognet.cli.exceptions import GracefulShutdown
 

--- a/mognet/cli/run.py
+++ b/mognet/cli/run.py
@@ -16,12 +16,12 @@ group = typer.Typer()
 
 @group.callback()
 def run(
-    include_queues: Optional[str] = typer.Option(
+    include_queues: Optional[str] = typer.Option(  # noqa: B008
         None,
         metavar="include-queues",
         help="Comma-separated list of the ONLY queues to listen on.",
     ),
-    exclude_queues: Optional[str] = typer.Option(
+    exclude_queues: Optional[str] = typer.Option(  # noqa: B008
         None,
         metavar="exclude-queues",
         help="Comma-separated list of the ONLY queues to NOT listen on.",

--- a/mognet/cli/run_in_loop.py
+++ b/mognet/cli/run_in_loop.py
@@ -1,15 +1,21 @@
 import asyncio
 from functools import wraps
+from typing import Any, Awaitable, Callable, TypeVar
+
+from typing_extensions import ParamSpec
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
-def run_in_loop(f):
+def run_in_loop(f: Callable[_P, Awaitable[_R]]) -> Callable[_P, _R]:
     """
     Utility to run a click/typer command function in an event loop
     (because they don't support it out of the box)
     """
 
     @wraps(f)
-    def in_loop(*args, **kwargs):
+    def in_loop(*args: Any, **kwargs: Any) -> _R:
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(f(*args, **kwargs))
 

--- a/mognet/cli/tasks.py
+++ b/mognet/cli/tasks.py
@@ -32,7 +32,7 @@ async def get(
         metavar="include-value",
         help="If passed, the task's result (or exception) will be printed",
     ),
-):
+) -> None:
     """Get a task's details"""
 
     async with state["app_instance"] as app:
@@ -88,7 +88,7 @@ async def revoke(
         metavar="force",
         help="Attempt revoking anyway if the result is complete. Helps cleaning up cases where subtasks may have been spawned.",
     ),
-):
+) -> None:
     """Revoke a task"""
 
     async with state["app_instance"] as app:
@@ -124,7 +124,7 @@ async def tree(
     max_depth: int = typer.Option(3, metavar="max-depth"),
     max_width: int = typer.Option(16, metavar="max-width"),
     poll: Optional[int] = typer.Option(None, metavar="poll"),
-):
+) -> None:
     """Get the tree (descendants) of a task"""
 
     async with state["app_instance"] as app:
@@ -144,7 +144,9 @@ async def tree(
             if format == "text":
                 t = treelib.Tree()
 
-                def build_tree(n: ResultTree, parent: Optional[ResultTree] = None):
+                def build_tree(
+                    n: ResultTree, parent: Optional[ResultTree] = None
+                ) -> None:
                     t.create_node(
                         tag=text_label_format.format(**n.dict()),
                         identifier=n.result.id,

--- a/mognet/cli/tasks.py
+++ b/mognet/cli/tasks.py
@@ -22,12 +22,12 @@ group = typer.Typer()
 @group.command("get")
 @run_in_loop
 async def get(
-    task_id: UUID = typer.Argument(
+    task_id: UUID = typer.Argument(  # noqa: B008
         ...,
         metavar="id",
         help="Task ID to get",
     ),
-    include_value: bool = typer.Option(
+    include_value: bool = typer.Option(  # noqa: B008
         False,
         metavar="include-value",
         help="If passed, the task's result (or exception) will be printed",
@@ -78,12 +78,12 @@ async def get(
 @group.command("revoke")
 @run_in_loop
 async def revoke(
-    task_id: UUID = typer.Argument(
+    task_id: UUID = typer.Argument(  # noqa: B008
         ...,
         metavar="id",
         help="Task ID to revoke",
     ),
-    force: bool = typer.Option(
+    force: bool = typer.Option(  # noqa: B008
         False,
         metavar="force",
         help="Attempt revoking anyway if the result is complete. Helps cleaning up cases where subtasks may have been spawned.",
@@ -109,21 +109,23 @@ async def revoke(
 @group.command("tree")
 @run_in_loop
 async def tree(
-    task_id: UUID = typer.Argument(
+    task_id: UUID = typer.Argument(  # noqa: B008
         ...,
         metavar="id",
         help="Task ID to get tree from",
     ),
-    format: OutputFormat = typer.Option(OutputFormat.TEXT, metavar="format"),
-    json_indent: int = typer.Option(2, metavar="json-indent"),
-    text_label_format: str = typer.Option(
+    format: OutputFormat = typer.Option(  # noqa: B008
+        OutputFormat.TEXT, metavar="format"
+    ),  # noqa: B008
+    json_indent: int = typer.Option(2, metavar="json-indent"),  # noqa: B008
+    text_label_format: str = typer.Option(  # noqa: B008
         "{name}(id={id!r}, state={state!r})",
         metavar="text-label-format",
         help="Label format for text format",
     ),
-    max_depth: int = typer.Option(3, metavar="max-depth"),
-    max_width: int = typer.Option(16, metavar="max-width"),
-    poll: Optional[int] = typer.Option(None, metavar="poll"),
+    max_depth: int = typer.Option(3, metavar="max-depth"),  # noqa: B008
+    max_width: int = typer.Option(16, metavar="max-width"),  # noqa: B008
+    poll: Optional[int] = typer.Option(None, metavar="poll"),  # noqa: B008
 ) -> None:
     """Get the tree (descendants) of a task"""
 
@@ -144,19 +146,7 @@ async def tree(
             if format == "text":
                 t = treelib.Tree()
 
-                def build_tree(
-                    n: ResultTree, parent: Optional[ResultTree] = None
-                ) -> None:
-                    t.create_node(
-                        tag=text_label_format.format(**n.dict()),
-                        identifier=n.result.id,
-                        parent=None if parent is None else parent.result.id,
-                    )
-
-                    for c in n.children:
-                        build_tree(c, parent=n)
-
-                build_tree(tree)
+                _build_tree(t, text_label_format, tree)
 
                 t.show()
 
@@ -167,3 +157,19 @@ async def tree(
                 break
 
             await asyncio.sleep(poll)
+
+
+def _build_tree(
+    t: treelib.Tree,
+    text_label_format: str,
+    n: ResultTree,
+    parent: Optional[ResultTree] = None,
+) -> None:
+    t.create_node(
+        tag=text_label_format.format(**n.dict()),
+        identifier=n.result.id,
+        parent=None if parent is None else parent.result.id,
+    )
+
+    for c in n.children:
+        _build_tree(t, text_label_format, c, parent=n)

--- a/mognet/cli/tasks.py
+++ b/mognet/cli/tasks.py
@@ -1,16 +1,17 @@
 import asyncio
-import treelib
 import logging
 from typing import Optional
 from uuid import UUID
 
 import tabulate
+import treelib
 import typer
+
+from mognet.cli.cli_state import state
 from mognet.cli.models import OutputFormat
 from mognet.cli.run_in_loop import run_in_loop
 from mognet.exceptions.result_exceptions import ResultValueLost
 from mognet.model.result import _ExceptionInfo
-from mognet.cli.cli_state import state
 from mognet.model.result_tree import ResultTree
 
 _log = logging.getLogger(__name__)

--- a/mognet/context/context.py
+++ b/mognet/context/context.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 if sys.version_info >= (3, 10):
-    from typing import ParamSpec, Concatenate
+    from typing import Concatenate, ParamSpec
 else:
     from typing_extensions import ParamSpec, Concatenate
 
@@ -98,7 +98,7 @@ class Context:
         self,
         request: Callable[Concatenate["Context", _P], _Return],
         *args: _P.args,
-        **kwargs: _P.kwargs
+        **kwargs: _P.kwargs,
     ) -> _Return:
         """
         Short-hand method for creating a Request from a function decorated with `@task`,
@@ -114,7 +114,7 @@ class Context:
         self,
         request: Callable[Concatenate["Context", _P], Awaitable[_Return]],
         *args: _P.args,
-        **kwargs: _P.kwargs
+        **kwargs: _P.kwargs,
     ) -> _Return:
         """
         Short-hand method for creating a Request from a function decorated with `@task`,
@@ -211,7 +211,7 @@ class Context:
         self,
         func: Callable[Concatenate["Context", _P], _Return],
         *args: _P.args,
-        **kwargs: _P.kwargs
+        **kwargs: _P.kwargs,
     ) -> _Return:
         ...
 

--- a/mognet/context/context.py
+++ b/mognet/context/context.py
@@ -9,9 +9,6 @@ from typing import (
     Any,
     Awaitable,
     Callable,
-    Coroutine,
-    Dict,
-    Generic,
     List,
     Optional,
     Set,
@@ -40,7 +37,6 @@ _Return = TypeVar("_Return")
 
 if TYPE_CHECKING:
     from mognet.app.app import App
-    from mognet.model.result import Result
     from mognet.state.state import State
     from mognet.worker.worker import Worker
 

--- a/mognet/decorators/task_decorator.py
+++ b/mognet/decorators/task_decorator.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any, Callable, Optional, TypeVar, cast
+
 from mognet.tasks.task_registry import TaskRegistry, task_registry
 
 _log = logging.getLogger(__name__)

--- a/mognet/decorators/task_decorator.py
+++ b/mognet/decorators/task_decorator.py
@@ -6,10 +6,10 @@ from mognet.tasks.task_registry import TaskRegistry, task_registry
 _log = logging.getLogger(__name__)
 
 
-_T = TypeVar("_T")
+_T = TypeVar("_T", bound=Callable[..., Any])
 
 
-def task(*, name: Optional[str] = None):
+def task(*, name: Optional[str] = None) -> Callable[[_T], _T]:
     """
     Register a function as a task that can be run.
 
@@ -30,7 +30,7 @@ def task(*, name: Optional[str] = None):
             reg = TaskRegistry()
             reg.register_globally()
 
-        reg.add_task_function(cast(Callable, t), name=name)
+        reg.add_task_function(cast(Callable[..., Any], t), name=name)
 
         return t
 

--- a/mognet/exceptions/result_exceptions.py
+++ b/mognet/exceptions/result_exceptions.py
@@ -1,7 +1,7 @@
-from mognet.exceptions.base_exceptions import MognetError
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from mognet.exceptions.base_exceptions import MognetError
 
 if TYPE_CHECKING:
     from mognet.model.result import Result

--- a/mognet/exceptions/result_exceptions.py
+++ b/mognet/exceptions/result_exceptions.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from mognet.exceptions.base_exceptions import MognetError
@@ -16,7 +16,7 @@ class ResultNotReady(ResultError):
 
 
 class ResultFailed(ResultError):
-    def __init__(self, result: "Result") -> None:
+    def __init__(self, result: "Result[Any]") -> None:
         super().__init__(result)
         self.result = result
 

--- a/mognet/exceptions/task_exceptions.py
+++ b/mognet/exceptions/task_exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, Union
+from typing import List, Tuple, Union
 
 from pydantic import BaseModel
 from pydantic.error_wrappers import ValidationError

--- a/mognet/exceptions/task_exceptions.py
+++ b/mognet/exceptions/task_exceptions.py
@@ -1,6 +1,7 @@
+from typing import Any, Dict, List, Tuple, Union
+
 from pydantic import BaseModel
 from pydantic.error_wrappers import ValidationError
-from typing import Any, Dict, List, Tuple, Union
 
 # Taken from pydantic.error_wrappers
 Loc = Tuple[Union[int, str], ...]

--- a/mognet/exceptions/task_exceptions.py
+++ b/mognet/exceptions/task_exceptions.py
@@ -34,5 +34,7 @@ class InvalidTaskArguments(Exception):
         self.errors = errors
 
     @classmethod
-    def from_validation_error(cls, validation_error: ValidationError):
+    def from_validation_error(
+        cls, validation_error: ValidationError
+    ) -> "InvalidTaskArguments":
         return cls([InvalidErrorInfo.parse_obj(e) for e in validation_error.errors()])

--- a/mognet/middleware/middleware.py
+++ b/mognet/middleware/middleware.py
@@ -8,10 +8,10 @@ else:
 
 
 if TYPE_CHECKING:
+    from mognet.app.app import App
     from mognet.context.context import Context
     from mognet.model.result import Result
     from mognet.primitives.request import Request
-    from mognet.app.app import App
 
 
 class Middleware(Protocol):

--- a/mognet/middleware/middleware.py
+++ b/mognet/middleware/middleware.py
@@ -1,13 +1,4 @@
-import sys
 from typing import TYPE_CHECKING, Any, Optional
-
-from mognet.model.result import Result
-
-if sys.version_info >= (3, 10):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
-
 
 if TYPE_CHECKING:
     from mognet.app.app import App

--- a/mognet/middleware/middleware.py
+++ b/mognet/middleware/middleware.py
@@ -1,5 +1,7 @@
 import sys
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+from mognet.model.result import Result
 
 if sys.version_info >= (3, 10):
     from typing import Protocol
@@ -14,7 +16,7 @@ if TYPE_CHECKING:
     from mognet.primitives.request import Request
 
 
-class Middleware(Protocol):
+class Middleware:
     """
     Defines middleware that can hook into different parts of a Mognet App's lifecycle.
     """
@@ -47,7 +49,7 @@ class Middleware(Protocol):
         For example, you can use this for cleaning up objects that were previously set up.
         """
 
-    async def on_task_starting(self, context: "Context"):
+    async def on_task_starting(self, context: "Context") -> None:
         """
         Called when a task is starting.
 
@@ -55,8 +57,8 @@ class Middleware(Protocol):
         """
 
     async def on_task_completed(
-        self, result: "Result", context: Optional["Context"] = None
-    ):
+        self, result: "Result[Any]", context: Optional["Context"] = None
+    ) -> None:
         """
         Called when a task has completed it's execution.
 
@@ -64,8 +66,8 @@ class Middleware(Protocol):
         """
 
     async def on_request_submitting(
-        self, request: "Request", context: Optional["Context"] = None
-    ):
+        self, request: "Request[Any]", context: Optional["Context"] = None
+    ) -> None:
         """
         Called when a Request object is going to be submitted to the Broker.
 
@@ -73,7 +75,7 @@ class Middleware(Protocol):
         the Request object (e.g., to modify arguments, or set metadata).
         """
 
-    async def on_running_task_count_changed(self, running_task_count: int):
+    async def on_running_task_count_changed(self, running_task_count: int) -> None:
         """
         Called when the Worker's task count changes.
 

--- a/mognet/model/result.py
+++ b/mognet/model/result.py
@@ -9,45 +9,43 @@ from datetime import datetime, timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncGenerator,
     AsyncIterable,
-    Awaitable,
     Dict,
     Generator,
     Generic,
-    Iterable,
     Optional,
     Type,
     TypeVar,
-    cast,
 )
 from uuid import UUID
 
 from pydantic.fields import PrivateAttr
 from pydantic.main import BaseModel
 from pydantic.tools import parse_obj_as
-from typing_extensions import TypeAlias
 
 from mognet.exceptions.result_exceptions import ResultFailed, ResultNotReady, Revoked
+from mognet.model.result_state import (
+    ERROR_STATES,
+    READY_STATES,
+    SUCCESS_STATES,
+    ResultState,
+)
 from mognet.tools.dates import now_utc
-
-from .result_state import ERROR_STATES, READY_STATES, SUCCESS_STATES, ResultState
 
 if TYPE_CHECKING:
     from mognet.backend.base_result_backend import BaseResultBackend
 
     from .result_tree import ResultTree
 
-_log = logging.getLogger(__name__)
-
-_TSelf = TypeVar("_TSelf")
 _Return = TypeVar("_Return")
+
+_log = logging.getLogger(__name__)
 
 
 class ResultChildren:
     """The children of a Result."""
 
-    def __init__(self, result: " Result[Any]", backend: BaseResultBackend) -> None:
+    def __init__(self, result: "Result[Any]", backend: BaseResultBackend) -> None:
         self._result = result
         self._backend = backend
 

--- a/mognet/model/result.py
+++ b/mognet/model/result.py
@@ -1,32 +1,24 @@
 import base64
-from mognet.exceptions.result_exceptions import ResultFailed, ResultNotReady, Revoked
-import pickle
 import importlib
-import traceback
 import logging
-from typing import (
-    Any,
-    AsyncGenerator,
-    Dict,
-    Optional,
-    TYPE_CHECKING,
-)
-from .result_state import (
-    ERROR_STATES,
-    READY_STATES,
-    ResultState,
-    SUCCESS_STATES,
-)
-
+import pickle
+import traceback
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional
+from uuid import UUID
+
 from pydantic.fields import PrivateAttr
 from pydantic.main import BaseModel
-from mognet.tools.dates import now_utc
 from pydantic.tools import parse_obj_as
-from uuid import UUID
+
+from mognet.exceptions.result_exceptions import ResultFailed, ResultNotReady, Revoked
+from mognet.tools.dates import now_utc
+
+from .result_state import ERROR_STATES, READY_STATES, SUCCESS_STATES, ResultState
 
 if TYPE_CHECKING:
     from mognet.backend.base_result_backend import BaseResultBackend
+
     from .result_tree import ResultTree
 
 _log = logging.getLogger(__name__)

--- a/mognet/model/result_state.py
+++ b/mognet/model/result_state.py
@@ -29,7 +29,7 @@ class ResultState(str, Enum):
     # Invalid task
     INVALID = "INVALID"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.name!r}"
 
 

--- a/mognet/model/result_tree.py
+++ b/mognet/model/result_tree.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from pydantic import BaseModel
 
@@ -6,13 +6,13 @@ from .result import Result
 
 
 class ResultTree(BaseModel):
-    result: "Result"
+    result: Result[Any]
     children: List["ResultTree"]
 
     def __str__(self) -> str:
         return f"{self.result.name}(id={self.result.id!r}, state={self.result.state!r}, node_id={self.result.node_id!r})"
 
-    def dict(self, **kwargs):
+    def dict(self, **kwargs: Any) -> Dict[str, Any]:
         return {
             "id": self.result.id,
             "name": self.result.name,

--- a/mognet/model/result_tree.py
+++ b/mognet/model/result_tree.py
@@ -1,8 +1,8 @@
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import Any, Dict, List
 
 from pydantic import BaseModel
 
-from .result import Result
+from mognet.model.result import Result
 
 
 class ResultTree(BaseModel):

--- a/mognet/model/result_tree.py
+++ b/mognet/model/result_tree.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from pydantic import BaseModel
 
 from .result import Result

--- a/mognet/primitives/queries.py
+++ b/mognet/primitives/queries.py
@@ -1,4 +1,4 @@
-from typing import List, Literal
+from typing import Any, Dict, List, Literal
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
@@ -14,7 +14,7 @@ class QueryResponseMessage(BaseModel):
 
     kind: str
     node_id: str
-    payload: BaseModel
+    payload: Any
 
 
 class StatusResponseMessage(QueryResponseMessage):

--- a/mognet/primitives/queries.py
+++ b/mognet/primitives/queries.py
@@ -1,5 +1,6 @@
-from uuid import UUID, uuid4
 from typing import List, Literal
+from uuid import UUID, uuid4
+
 from pydantic import BaseModel, Field
 
 

--- a/mognet/primitives/queries.py
+++ b/mognet/primitives/queries.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal
+from typing import Any, List, Literal
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field

--- a/mognet/primitives/queries.py
+++ b/mognet/primitives/queries.py
@@ -14,7 +14,7 @@ class QueryResponseMessage(BaseModel):
 
     kind: str
     node_id: str
-    payload: dict
+    payload: BaseModel
 
 
 class StatusResponseMessage(QueryResponseMessage):

--- a/mognet/primitives/request.py
+++ b/mognet/primitives/request.py
@@ -1,11 +1,10 @@
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 from uuid import UUID, uuid4
-from pydantic import conint
 
+from pydantic import conint
 from pydantic.fields import Field
 from pydantic.generics import GenericModel
-
 
 TReturn = TypeVar("TReturn")
 

--- a/mognet/primitives/request.py
+++ b/mognet/primitives/request.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
-from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union
+from typing_extensions import TypeAlias
 from uuid import UUID, uuid4
 
 from pydantic import conint
@@ -8,7 +9,7 @@ from pydantic.generics import GenericModel
 
 TReturn = TypeVar("TReturn")
 
-Priority = conint(ge=0, le=10)
+Priority: TypeAlias = conint(ge=0, le=10)  # type: ignore
 
 
 class Request(GenericModel, Generic[TReturn]):

--- a/mognet/primitives/request.py
+++ b/mognet/primitives/request.py
@@ -1,22 +1,21 @@
 from datetime import datetime, timedelta
-from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union
-from typing_extensions import TypeAlias
+from typing import Any, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union
 from uuid import UUID, uuid4
 
-from pydantic import conint
+from pydantic import BaseModel, conint
 from pydantic.fields import Field
-from pydantic.generics import GenericModel
+from typing_extensions import TypeAlias
 
 TReturn = TypeVar("TReturn")
 
 Priority: TypeAlias = conint(ge=0, le=10)  # type: ignore
 
 
-class Request(GenericModel, Generic[TReturn]):
+class Request(BaseModel, Generic[TReturn]):
     id: UUID = Field(default_factory=uuid4)
     name: str
 
-    args: tuple = ()
+    args: Tuple[Any, ...] = ()
     kwargs: Dict[str, Any] = Field(default_factory=dict)
 
     stack: List[UUID] = Field(default_factory=list)
@@ -48,7 +47,7 @@ class Request(GenericModel, Generic[TReturn]):
     # Task priority. The higher the value, the higher the priority.
     priority: Priority = 5
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         msg = f"{self.name}[id={self.id!r}]"
 
         if self.kwargs_repr is not None:

--- a/mognet/primitives/request.py
+++ b/mognet/primitives/request.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, conint

--- a/mognet/primitives/request.py
+++ b/mognet/primitives/request.py
@@ -1,14 +1,26 @@
 from datetime import datetime, timedelta
-from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, conint
 from pydantic.fields import Field
-from typing_extensions import TypeAlias
 
 TReturn = TypeVar("TReturn")
 
-Priority: TypeAlias = conint(ge=0, le=10)  # type: ignore
+if TYPE_CHECKING:
+    Priority = int
+else:
+    Priority = conint(ge=0, le=10)
 
 
 class Request(BaseModel, Generic[TReturn]):

--- a/mognet/primitives/revoke.py
+++ b/mognet/primitives/revoke.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 from uuid import UUID
+
 from pydantic.main import BaseModel
 
 

--- a/mognet/service/class_service.py
+++ b/mognet/service/class_service.py
@@ -1,11 +1,13 @@
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Type, TypeVar
 
 if TYPE_CHECKING:
     from mognet.app.app_config import AppConfig
     from mognet.context.context import Context
 
 _TReturn = TypeVar("_TReturn")
+
+_TSelf = TypeVar("_TSelf")
 
 
 class ClassService(Generic[_TReturn], metaclass=ABCMeta):
@@ -26,17 +28,17 @@ class ClassService(Generic[_TReturn], metaclass=ABCMeta):
         self.config = config
 
     @abstractmethod
-    def __call__(self, context: "Context", *args, **kwds) -> _TReturn:
+    def __call__(self, context: "Context", *args: Any, **kwds: Any) -> _TReturn:
         raise NotImplementedError
 
-    def __enter__(self):
+    def __enter__(self: _TSelf) -> _TSelf:
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self.close()
 
-    def close(self):
+    def close(self) -> None:
         pass
 
-    async def wait_closed(self):
+    async def wait_closed(self) -> None:
         pass

--- a/mognet/service/class_service.py
+++ b/mognet/service/class_service.py
@@ -1,6 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, TypeVar, Generic
-
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
     from mognet.app.app_config import AppConfig

--- a/mognet/service/class_service.py
+++ b/mognet/service/class_service.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Generic, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 if TYPE_CHECKING:
     from mognet.app.app_config import AppConfig

--- a/mognet/state/base_state_backend.py
+++ b/mognet/state/base_state_backend.py
@@ -8,34 +8,34 @@ _TValue = TypeVar("_TValue")
 class BaseStateBackend(metaclass=ABCMeta):
     @abstractmethod
     async def get(
-        self, request_id: UUID, key: str, default: _TValue = None
+        self, request_id: UUID, key: str, default: Optional[_TValue] = None
     ) -> Optional[_TValue]:
         raise NotImplementedError
 
     @abstractmethod
-    async def set(self, request_id: UUID, key: str, value: Any):
+    async def set(self, request_id: UUID, key: str, value: Any) -> None:
         raise NotImplementedError
 
     @abstractmethod
     async def pop(
-        self, request_id: UUID, key: str, default: _TValue = None
+        self, request_id: UUID, key: str, default: Optional[_TValue] = None
     ) -> Optional[_TValue]:
         raise NotImplementedError
 
     @abstractmethod
-    async def clear(self, request_id: UUID):
+    async def clear(self, request_id: UUID) -> None:
         raise NotImplementedError
 
-    async def __aenter__(self):
+    async def __aenter__(self):  # type: ignore
         return self
 
-    async def __aexit__(self, *args, **kwargs):
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
         return None
 
     @abstractmethod
-    async def connect(self):
+    async def connect(self) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    async def close(self):
+    async def close(self) -> None:
         raise NotImplementedError

--- a/mognet/state/redis_state_backend.py
+++ b/mognet/state/redis_state_backend.py
@@ -2,16 +2,22 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 from uuid import UUID
 
 from redis.asyncio import from_url
-from typing_extensions import TypeAlias
 
 from mognet.exceptions.base_exceptions import NotConnected
 from mognet.state.base_state_backend import BaseStateBackend
 from mognet.state.state_backend_config import StateBackendConfig
 from mognet.tools.urls import censor_credentials
+
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
+
 
 if TYPE_CHECKING:
     from redis.asyncio import Redis  # noqa: F401

--- a/mognet/state/redis_state_backend.py
+++ b/mognet/state/redis_state_backend.py
@@ -5,7 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 from uuid import UUID
 
-from redis.asyncio import Redis, from_url
+from redis.asyncio import from_url
 from typing_extensions import TypeAlias
 
 from mognet.exceptions.base_exceptions import NotConnected
@@ -14,6 +14,8 @@ from mognet.state.state_backend_config import StateBackendConfig
 from mognet.tools.urls import censor_credentials
 
 if TYPE_CHECKING:
+    from redis.asyncio import Redis  # noqa: F401
+
     from mognet.app.app import App
 
 

--- a/mognet/state/state.py
+++ b/mognet/state/state.py
@@ -1,6 +1,5 @@
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
-
 
 if TYPE_CHECKING:
     from mognet import App

--- a/mognet/state/state.py
+++ b/mognet/state/state.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 if TYPE_CHECKING:
     from mognet import App
+    from mognet.state.base_state_backend import BaseStateBackend
 
 
 class State:
@@ -21,14 +24,14 @@ class State:
         self.request_id = request_id
 
     @property
-    def _backend(self):
+    def _backend(self) -> BaseStateBackend:
         return self._app.state_backend
 
     async def get(self, key: str, default: Any = None) -> Any:
         """Get a value."""
         return await self._backend.get(self.request_id, key, default)
 
-    async def set(self, key: str, value: Any):
+    async def set(self, key: str, value: Any) -> None:
         """Set a value."""
         return await self._backend.set(self.request_id, key, value)
 
@@ -36,6 +39,6 @@ class State:
         """Delete a value from the state and return it's value."""
         return await self._backend.pop(self.request_id, key, default)
 
-    async def clear(self):
+    async def clear(self) -> None:
         """Clear all values."""
         return await self._backend.clear(self.request_id)

--- a/mognet/state/state_backend_config.py
+++ b/mognet/state/state_backend_config.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from pydantic import BaseModel
 
 

--- a/mognet/tasks/task_registry.py
+++ b/mognet/tasks/task_registry.py
@@ -1,10 +1,8 @@
-from contextvars import ContextVar
 import logging
+from contextvars import ContextVar
+from typing import Any, Callable, Dict, List, Optional, Protocol
 
 from mognet.context.context import Context
-from typing import Any, Callable, Dict, List, Optional
-
-from typing import Protocol
 
 _log = logging.getLogger(__name__)
 

--- a/mognet/tasks/task_registry.py
+++ b/mognet/tasks/task_registry.py
@@ -19,7 +19,7 @@ class UnknownTask(KeyError):
         super().__init__(task_name)
         self.task_name = task_name
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Unknown task: {self.task_name!r}; did you forget to register it, or import it's module in the app's configuration?"
 
 
@@ -28,7 +28,7 @@ class TaskRegistry:
     _names_to_tasks: Dict[str, TaskProtocol]
     _tasks_to_names: Dict[TaskProtocol, str]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._names_to_tasks = {}
         self._tasks_to_names = {}
 
@@ -45,7 +45,9 @@ class TaskRegistry:
     def registered_task_names(self) -> List[str]:
         return list(self._names_to_tasks)
 
-    def add_task_function(self, func: Callable, *, name: Optional[str] = None):
+    def add_task_function(
+        self, func: TaskProtocol, *, name: Optional[str] = None
+    ) -> None:
         full_func_name = _get_full_func_name(func)
 
         if name is None:
@@ -61,11 +63,11 @@ class TaskRegistry:
 
         _log.debug("Registered function %r as task %r", full_func_name, name)
 
-    def register_globally(self):
+    def register_globally(self) -> None:
         task_registry.set(self)
 
 
-def _get_full_func_name(func) -> str:
+def _get_full_func_name(func: Any) -> str:
     func_name = getattr(func, "__qualname__", None) or getattr(func, "__name__", None)
 
     full_func_name = ".".join(

--- a/mognet/tasks/task_registry.py
+++ b/mognet/tasks/task_registry.py
@@ -1,6 +1,6 @@
 import logging
 from contextvars import ContextVar
-from typing import Any, Callable, Dict, List, Optional, Protocol
+from typing import Any, Dict, List, Optional, Protocol
 
 from mognet.context.context import Context
 

--- a/mognet/testing/pytest_integration.py
+++ b/mognet/testing/pytest_integration.py
@@ -1,15 +1,14 @@
 import asyncio
-from typing import AsyncIterable, Callable
+from typing import Any, AsyncIterable
 
 import pytest_asyncio
 
 from mognet import App
 
 
-def create_app_fixture(app: App) -> Callable[[], App]:
+def create_app_fixture(app: App) -> Any:
     """Create a Pytest fixture for a Mognet application."""
 
-    @pytest_asyncio.fixture  # type: ignore
     async def app_fixture() -> AsyncIterable[App]:
         async with app:
             start_task = asyncio.create_task(app.start())
@@ -22,4 +21,4 @@ def create_app_fixture(app: App) -> Callable[[], App]:
             except BaseException:  # pylint: disable=broad-except
                 pass
 
-    return app_fixture  # type: ignore
+    return pytest_asyncio.fixture(app_fixture)

--- a/mognet/testing/pytest_integration.py
+++ b/mognet/testing/pytest_integration.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import AsyncIterable, Callable
 
 import pytest
 import pytest_asyncio
@@ -6,11 +7,11 @@ import pytest_asyncio
 from mognet import App
 
 
-def create_app_fixture(app: App):
+def create_app_fixture(app: App) -> Callable[[], App]:
     """Create a Pytest fixture for a Mognet application."""
 
-    @pytest_asyncio.fixture
-    async def app_fixture():
+    @pytest_asyncio.fixture  # type: ignore
+    async def app_fixture() -> AsyncIterable[App]:
         async with app:
             start_task = asyncio.create_task(app.start())
             yield app
@@ -22,4 +23,4 @@ def create_app_fixture(app: App):
             except BaseException:  # pylint: disable=broad-except
                 pass
 
-    return app_fixture
+    return app_fixture  # type: ignore

--- a/mognet/testing/pytest_integration.py
+++ b/mognet/testing/pytest_integration.py
@@ -1,7 +1,6 @@
 import asyncio
 from typing import AsyncIterable, Callable
 
-import pytest
 import pytest_asyncio
 
 from mognet import App

--- a/mognet/testing/pytest_integration.py
+++ b/mognet/testing/pytest_integration.py
@@ -1,6 +1,8 @@
 import asyncio
+
 import pytest
 import pytest_asyncio
+
 from mognet import App
 
 

--- a/mognet/tools/backports/aioitertools.py
+++ b/mognet/tools/backports/aioitertools.py
@@ -6,7 +6,7 @@ Should be upstreamed here: https://github.com/omnilib/aioitertools/pull/103
 
 import asyncio
 from contextlib import suppress
-from typing import AsyncIterable, Iterable, TypeVar, AsyncGenerator
+from typing import AsyncGenerator, AsyncIterable, Iterable, TypeVar
 
 T = TypeVar("T")
 

--- a/mognet/tools/backports/aioitertools.py
+++ b/mognet/tools/backports/aioitertools.py
@@ -6,7 +6,7 @@ Should be upstreamed here: https://github.com/omnilib/aioitertools/pull/103
 
 import asyncio
 from contextlib import suppress
-from typing import AsyncGenerator, AsyncIterable, Iterable, TypeVar
+from typing import Any, AsyncGenerator, AsyncIterable, Dict, Iterable, TypeVar
 
 T = TypeVar("T")
 
@@ -34,7 +34,7 @@ async def as_generated(
             ...  # intermixed values yielded from gen1 and gen2
     """
 
-    queue: asyncio.Queue[dict] = asyncio.Queue()
+    queue: asyncio.Queue[Dict[Any, Any]] = asyncio.Queue()
 
     tailer_count: int = 0
 

--- a/mognet/tools/kwargs_repr.py
+++ b/mognet/tools/kwargs_repr.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Any, Optional
 
 
 def _format_value(value: Any, *, max_length: Optional[int]) -> str:

--- a/mognet/tools/kwargs_repr.py
+++ b/mognet/tools/kwargs_repr.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Dict, Optional, Tuple
 
 
 def _format_value(value: Any, *, max_length: Optional[int]) -> str:
@@ -11,8 +11,8 @@ def _format_value(value: Any, *, max_length: Optional[int]) -> str:
 
 
 def format_kwargs_repr(
-    args: tuple,
-    kwargs: dict,
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
     *,
     value_max_length: Optional[int] = 64,
 ) -> str:

--- a/mognet/tools/retries.py
+++ b/mognet/tools/retries.py
@@ -1,7 +1,7 @@
 import asyncio
+import inspect
 import logging
 from functools import wraps
-import inspect
 from typing import (
     Any,
     Awaitable,
@@ -13,7 +13,6 @@ from typing import (
     Union,
     cast,
 )
-
 
 _T = TypeVar("_T")
 

--- a/mognet/tools/retries.py
+++ b/mognet/tools/retries.py
@@ -2,18 +2,7 @@ import asyncio
 import inspect
 import logging
 from functools import wraps
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    NamedTuple,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Awaitable, Callable, Optional, Tuple, Type, TypeVar, Union, cast
 
 _T = TypeVar("_T")
 

--- a/mognet/tools/retries.py
+++ b/mognet/tools/retries.py
@@ -7,6 +7,7 @@ from typing import (
     Awaitable,
     Callable,
     NamedTuple,
+    Optional,
     Tuple,
     Type,
     TypeVar,
@@ -19,7 +20,7 @@ _T = TypeVar("_T")
 _log = logging.getLogger(__name__)
 
 
-async def _noop(*args, **kwargs):
+async def _noop(*args: Any, **kwargs: Any) -> None:
     pass
 
 
@@ -28,9 +29,9 @@ def retryableasyncmethod(
     *,
     max_attempts: Union[int, str],
     wait_timeout: Union[float, str],
-    lock: Union[asyncio.Lock, str] = None,
-    on_retry: Union[Callable[[BaseException], Awaitable], str] = None,
-):
+    lock: Optional[Union[asyncio.Lock, str]] = None,
+    on_retry: Optional[Union[Callable[[BaseException], Awaitable[Any]], str]] = None,
+) -> Callable[[_T], _T]:
     """
     Decorator to wrap an async method and make it retryable.
     """
@@ -42,10 +43,12 @@ def retryableasyncmethod(
         f: Any = cast(Any, func)
 
         @wraps(f)
-        async def async_retryable_decorator(self, *args, **kwargs):
+        async def async_retryable_decorator(
+            self: Any, *args: Any, **kwargs: Any
+        ) -> Any:
             last_exc = None
 
-            retry = _noop
+            retry: Callable[..., Any] = _noop
             if isinstance(on_retry, str):
                 retry = getattr(self, on_retry)
             elif callable(on_retry):

--- a/mognet/worker/worker.py
+++ b/mognet/worker/worker.py
@@ -6,16 +6,7 @@ import logging
 from asyncio.futures import Future
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AsyncGenerator,
-    AsyncIterable,
-    Dict,
-    List,
-    Optional,
-    Set,
-)
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Set
 from uuid import UUID
 
 from pydantic import ValidationError

--- a/mognet/worker/worker.py
+++ b/mognet/worker/worker.py
@@ -1,32 +1,24 @@
-from datetime import datetime, timedelta
-from enum import Enum
-import inspect
-
-from mognet.exceptions.task_exceptions import InvalidTaskArguments, Pause
 import asyncio
+import inspect
 import logging
 from asyncio.futures import Future
-from mognet.broker.base_broker import IncomingMessagePayload
-from typing import (
-    AsyncGenerator,
-    Optional,
-    Set,
-    TYPE_CHECKING,
-    Dict,
-    List,
-)
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import TYPE_CHECKING, AsyncGenerator, Dict, List, Optional, Set
 from uuid import UUID
 
-from mognet.tools.backports.aioitertools import as_generated
-from mognet.broker.base_broker import IncomingMessagePayload
-from mognet.context.context import Context
-from mognet.exceptions.too_many_retries import TooManyRetries
-from mognet.model.result import Result, ResultState
-from mognet.state.state import State
-from mognet.tasks.task_registry import UnknownTask
 from pydantic import ValidationError
 from pydantic.decorator import ValidatedFunction
+
+from mognet.broker.base_broker import IncomingMessagePayload
+from mognet.context.context import Context
+from mognet.exceptions.task_exceptions import InvalidTaskArguments, Pause
+from mognet.exceptions.too_many_retries import TooManyRetries
+from mognet.model.result import Result, ResultState
 from mognet.primitives.request import Request
+from mognet.state.state import State
+from mognet.tasks.task_registry import UnknownTask
+from mognet.tools.backports.aioitertools import as_generated
 
 if TYPE_CHECKING:
     from mognet.app.app import App

--- a/poetry.lock
+++ b/poetry.lock
@@ -174,6 +174,34 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, 
 graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
+name = "flake8"
+version = "4.0.1"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.8.0,<2.9.0"
+pyflakes = ">=2.4.0,<2.5.0"
+
+[[package]]
+name = "flake8-bugbear"
+version = "22.7.1"
+description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+flake8 = ">=3.0.0"
+
+[package.extras]
+dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit"]
+
+[[package]]
 name = "future"
 version = "0.18.2"
 description = "Clean single-source support for Python 3 and 2"
@@ -295,11 +323,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "mccabe"
-version = "0.7.0"
+version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = "*"
 
 [[package]]
 name = "mergedeep"
@@ -514,6 +542,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "pycodestyle"
+version = "2.8.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "pydantic"
 version = "1.9.1"
 description = "Data validation and settings management using python type hints"
@@ -527,6 +563,14 @@ typing-extensions = ">=3.7.4.3"
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
+
+[[package]]
+name = "pyflakes"
+version = "2.4.0"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pygments"
@@ -816,7 +860,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "afa2a3a1749187277e3130c1a0414e0d1479825a44c7e96e556c6b0692265289"
+content-hash = "57196e45c63b185c8c20bffa358f4a2d55ff81de92c6e6f71215b64f91bd7260"
 
 [metadata.files]
 aio-pika = [
@@ -893,6 +937,8 @@ dill = [
     {file = "dill-0.3.5.1-py2.py3-none-any.whl", hash = "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302"},
     {file = "dill-0.3.5.1.tar.gz", hash = "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"},
 ]
+flake8 = []
+flake8-bugbear = []
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
@@ -1049,8 +1095,8 @@ markupsafe = [
     {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
 ]
 mccabe = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mergedeep = [
     {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
@@ -1174,6 +1220,7 @@ py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
+pycodestyle = []
 pydantic = [
     {file = "pydantic-1.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c8098a724c2784bf03e8070993f6d46aa2eeca031f8d8a048dff277703e6e193"},
     {file = "pydantic-1.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c320c64dd876e45254bdd350f0179da737463eea41c43bacbee9d8c9d1021f11"},
@@ -1211,6 +1258,7 @@ pydantic = [
     {file = "pydantic-1.9.1-py3-none-any.whl", hash = "sha256:4988c0f13c42bfa9ddd2fe2f569c9d54646ce84adc5de84228cfe83396f3bd58"},
     {file = "pydantic-1.9.1.tar.gz", hash = "sha256:1ed987c3ff29fff7fd8c3ea3a3ea877ad310aae2ef9889a119e22d3f2db0691a"},
 ]
+pyflakes = []
 pygments = [
     {file = "Pygments-2.12.0-py3-none-any.whl", hash = "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"},
     {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -136,7 +136,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.4.1"
+version = "6.4.2"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -424,6 +424,24 @@ description = "multidict implementation"
 category = "main"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "mypy"
+version = "0.961"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=3.10"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
@@ -729,6 +747,22 @@ doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "mdx-inclu
 test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=22.3.0,<23.0.0)", "isort (>=5.0.6,<6.0.0)"]
 
 [[package]]
+name = "types-redis"
+version = "4.3.4"
+description = "Typing stubs for redis"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "types-tabulate"
+version = "0.8.11"
+description = "Typing stubs for tabulate"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.2.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -782,7 +816,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c97cd5c310883b45785f9159e6b97d2caecdb6cb4a71d5969c0909f35e8ad1be"
+content-hash = "afa2a3a1749187277e3130c1a0414e0d1479825a44c7e96e556c6b0692265289"
 
 [metadata.files]
 aio-pika = [
@@ -850,49 +884,7 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
-coverage = [
-    {file = "coverage-6.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b"},
-    {file = "coverage-6.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4ce1b258493cbf8aec43e9b50d89982346b98e9ffdfaae8ae5793bc112fb0068"},
-    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c4e737f60c6936460c5be330d296dd5b48b3963f48634c53b3f7deb0f34ec4"},
-    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84e65ef149028516c6d64461b95a8dbcfce95cfd5b9eb634320596173332ea84"},
-    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f69718750eaae75efe506406c490d6fc5a6161d047206cc63ce25527e8a3adad"},
-    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e57816f8ffe46b1df8f12e1b348f06d164fd5219beba7d9433ba79608ef011cc"},
-    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:01c5615d13f3dd3aa8543afc069e5319cfa0c7d712f6e04b920431e5c564a749"},
-    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:75ab269400706fab15981fd4bd5080c56bd5cc07c3bccb86aab5e1d5a88dc8f4"},
-    {file = "coverage-6.4.1-cp310-cp310-win32.whl", hash = "sha256:a7f3049243783df2e6cc6deafc49ea123522b59f464831476d3d1448e30d72df"},
-    {file = "coverage-6.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:ee2ddcac99b2d2aec413e36d7a429ae9ebcadf912946b13ffa88e7d4c9b712d6"},
-    {file = "coverage-6.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb73e0011b8793c053bfa85e53129ba5f0250fdc0392c1591fd35d915ec75c46"},
-    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:106c16dfe494de3193ec55cac9640dd039b66e196e4641fa8ac396181578b982"},
-    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87f4f3df85aa39da00fd3ec4b5abeb7407e82b68c7c5ad181308b0e2526da5d4"},
-    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:961e2fb0680b4f5ad63234e0bf55dfb90d302740ae9c7ed0120677a94a1590cb"},
-    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:cec3a0f75c8f1031825e19cd86ee787e87cf03e4fd2865c79c057092e69e3a3b"},
-    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:129cd05ba6f0d08a766d942a9ed4b29283aff7b2cccf5b7ce279d50796860bb3"},
-    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bf5601c33213d3cb19d17a796f8a14a9eaa5e87629a53979a5981e3e3ae166f6"},
-    {file = "coverage-6.4.1-cp37-cp37m-win32.whl", hash = "sha256:269eaa2c20a13a5bf17558d4dc91a8d078c4fa1872f25303dddcbba3a813085e"},
-    {file = "coverage-6.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f02cbbf8119db68455b9d763f2f8737bb7db7e43720afa07d8eb1604e5c5ae28"},
-    {file = "coverage-6.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ffa9297c3a453fba4717d06df579af42ab9a28022444cae7fa605af4df612d54"},
-    {file = "coverage-6.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:145f296d00441ca703a659e8f3eb48ae39fb083baba2d7ce4482fb2723e050d9"},
-    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d44996140af8b84284e5e7d398e589574b376fb4de8ccd28d82ad8e3bea13"},
-    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bd9a6fc18aab8d2e18f89b7ff91c0f34ff4d5e0ba0b33e989b3cd4194c81fd9"},
-    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3384f2a3652cef289e38100f2d037956194a837221edd520a7ee5b42d00cc605"},
-    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9b3e07152b4563722be523e8cd0b209e0d1a373022cfbde395ebb6575bf6790d"},
-    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1480ff858b4113db2718848d7b2d1b75bc79895a9c22e76a221b9d8d62496428"},
-    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:865d69ae811a392f4d06bde506d531f6a28a00af36f5c8649684a9e5e4a85c83"},
-    {file = "coverage-6.4.1-cp38-cp38-win32.whl", hash = "sha256:664a47ce62fe4bef9e2d2c430306e1428ecea207ffd68649e3b942fa8ea83b0b"},
-    {file = "coverage-6.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:26dff09fb0d82693ba9e6231248641d60ba606150d02ed45110f9ec26404ed1c"},
-    {file = "coverage-6.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9c80df769f5ec05ad21ea34be7458d1dc51ff1fb4b2219e77fe24edf462d6df"},
-    {file = "coverage-6.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:39ee53946bf009788108b4dd2894bf1349b4e0ca18c2016ffa7d26ce46b8f10d"},
-    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5b66caa62922531059bc5ac04f836860412f7f88d38a476eda0a6f11d4724f4"},
-    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd180ed867e289964404051a958f7cccabdeed423f91a899829264bb7974d3d3"},
-    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84631e81dd053e8a0d4967cedab6db94345f1c36107c71698f746cb2636c63e3"},
-    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8c08da0bd238f2970230c2a0d28ff0e99961598cb2e810245d7fc5afcf1254e8"},
-    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d42c549a8f41dc103a8004b9f0c433e2086add8a719da00e246e17cbe4056f72"},
-    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:309ce4a522ed5fca432af4ebe0f32b21d6d7ccbb0f5fcc99290e71feba67c264"},
-    {file = "coverage-6.4.1-cp39-cp39-win32.whl", hash = "sha256:fdb6f7bd51c2d1714cea40718f6149ad9be6a2ee7d93b19e9f00934c0f2a74d9"},
-    {file = "coverage-6.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:342d4aefd1c3e7f620a13f4fe563154d808b69cccef415415aece4c786665397"},
-    {file = "coverage-6.4.1-pp36.pp37.pp38-none-any.whl", hash = "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815"},
-    {file = "coverage-6.4.1.tar.gz", hash = "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c"},
-]
+coverage = []
 deprecated = [
     {file = "Deprecated-1.2.13-py2.py3-none-any.whl", hash = "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"},
     {file = "Deprecated-1.2.13.tar.gz", hash = "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d"},
@@ -1153,6 +1145,7 @@ multidict = [
     {file = "multidict-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:4bae31803d708f6f15fd98be6a6ac0b6958fcf68fda3c77a048a4f9073704aae"},
     {file = "multidict-6.0.2.tar.gz", hash = "sha256:5ff3bd75f38e4c43f1f470f2df7a4d430b821c4ce22be384e1459cb57d6bb013"},
 ]
+mypy = []
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -1318,6 +1311,8 @@ typer = [
     {file = "typer-0.4.1-py3-none-any.whl", hash = "sha256:e8467f0ebac0c81366c2168d6ad9f888efdfb6d4e1d3d5b4a004f46fa444b5c3"},
     {file = "typer-0.4.1.tar.gz", hash = "sha256:5646aef0d936b2c761a10393f0384ee6b5c7fe0bb3e5cd710b17134ca1d99cff"},
 ]
+types-redis = []
+types-tabulate = []
 typing-extensions = [
     {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
     {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -136,14 +136,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.3.3"
+version = "6.4.1"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
 
 [package.extras]
 toml = ["tomli"]
@@ -657,7 +657,7 @@ pyyaml = "*"
 
 [[package]]
 name = "redis"
-version = "4.3.1"
+version = "4.3.4"
 description = "Python client for Redis database and key-value store"
 category = "main"
 optional = false
@@ -782,7 +782,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "bdf23376d830298b4ecb4eae9cba31205922455bb0717246fb93b8178d077d16"
+content-hash = "c97cd5c310883b45785f9159e6b97d2caecdb6cb4a71d5969c0909f35e8ad1be"
 
 [metadata.files]
 aio-pika = [
@@ -851,47 +851,47 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-6.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df32ee0f4935a101e4b9a5f07b617d884a531ed5666671ff6ac66d2e8e8246d8"},
-    {file = "coverage-6.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:75b5dbffc334e0beb4f6c503fb95e6d422770fd2d1b40a64898ea26d6c02742d"},
-    {file = "coverage-6.3.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:114944e6061b68a801c5da5427b9173a0dd9d32cd5fcc18a13de90352843737d"},
-    {file = "coverage-6.3.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ab88a01cd180b5640ccc9c47232e31924d5f9967ab7edd7e5c91c68eee47a69"},
-    {file = "coverage-6.3.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad8f9068f5972a46d50fe5f32c09d6ee11da69c560fcb1b4c3baea246ca4109b"},
-    {file = "coverage-6.3.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4cd696aa712e6cd16898d63cf66139dc70d998f8121ab558f0e1936396dbc579"},
-    {file = "coverage-6.3.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c1a9942e282cc9d3ed522cd3e3cab081149b27ea3bda72d6f61f84eaf88c1a63"},
-    {file = "coverage-6.3.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c06455121a089252b5943ea682187a4e0a5cf0a3fb980eb8e7ce394b144430a9"},
-    {file = "coverage-6.3.3-cp310-cp310-win32.whl", hash = "sha256:cb5311d6ccbd22578c80028c5e292a7ab9adb91bd62c1982087fad75abe2e63d"},
-    {file = "coverage-6.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:6d4a6f30f611e657495cc81a07ff7aa8cd949144e7667c5d3e680d73ba7a70e4"},
-    {file = "coverage-6.3.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:79bf405432428e989cad7b8bc60581963238f7645ae8a404f5dce90236cc0293"},
-    {file = "coverage-6.3.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:338c417613f15596af9eb7a39353b60abec9d8ce1080aedba5ecee6a5d85f8d3"},
-    {file = "coverage-6.3.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:db094a6a4ae6329ed322a8973f83630b12715654c197dd392410400a5bfa1a73"},
-    {file = "coverage-6.3.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1414e8b124611bf4df8d77215bd32cba6e3425da8ce9c1f1046149615e3a9a31"},
-    {file = "coverage-6.3.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:93b16b08f94c92cab88073ffd185070cdcb29f1b98df8b28e6649145b7f2c90d"},
-    {file = "coverage-6.3.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:fbc86ae8cc129c801e7baaafe3addf3c8d49c9c1597c44bdf2d78139707c3c62"},
-    {file = "coverage-6.3.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:b5ba058610e8289a07db2a57bce45a1793ec0d3d11db28c047aae2aa1a832572"},
-    {file = "coverage-6.3.3-cp37-cp37m-win32.whl", hash = "sha256:8329635c0781927a2c6ae068461e19674c564e05b86736ab8eb29c420ee7dc20"},
-    {file = "coverage-6.3.3-cp37-cp37m-win_amd64.whl", hash = "sha256:e5af1feee71099ae2e3b086ec04f57f9950e1be9ecf6c420696fea7977b84738"},
-    {file = "coverage-6.3.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e814a4a5a1d95223b08cdb0f4f57029e8eab22ffdbae2f97107aeef28554517e"},
-    {file = "coverage-6.3.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:61f4fbf3633cb0713437291b8848634ea97f89c7e849c2be17a665611e433f53"},
-    {file = "coverage-6.3.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3401b0d2ed9f726fadbfa35102e00d1b3547b73772a1de5508ef3bdbcb36afe7"},
-    {file = "coverage-6.3.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8586b177b4407f988731eb7f41967415b2197f35e2a6ee1a9b9b561f6323c8e9"},
-    {file = "coverage-6.3.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:892e7fe32191960da559a14536768a62e83e87bbb867e1b9c643e7e0fbce2579"},
-    {file = "coverage-6.3.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:afb03f981fadb5aed1ac6e3dd34f0488e1a0875623d557b6fad09b97a942b38a"},
-    {file = "coverage-6.3.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:cbe91bc84be4e5ef0b1480d15c7b18e29c73bdfa33e07d3725da7d18e1b0aff2"},
-    {file = "coverage-6.3.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:91502bf27cbd5c83c95cfea291ef387469f2387508645602e1ca0fd8a4ba7548"},
-    {file = "coverage-6.3.3-cp38-cp38-win32.whl", hash = "sha256:c488db059848702aff30aa1d90ef87928d4e72e4f00717343800546fdbff0a94"},
-    {file = "coverage-6.3.3-cp38-cp38-win_amd64.whl", hash = "sha256:ceb6534fcdfb5c503affb6b1130db7b5bfc8a0f77fa34880146f7a5c117987d0"},
-    {file = "coverage-6.3.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cc692c9ee18f0dd3214843779ba6b275ee4bb9b9a5745ba64265bce911aefd1a"},
-    {file = "coverage-6.3.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:462105283de203df8de58a68c1bb4ba2a8a164097c2379f664fa81d6baf94b81"},
-    {file = "coverage-6.3.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc972d829ad5ef4d4c5fcabd2bbe2add84ce8236f64ba1c0c72185da3a273130"},
-    {file = "coverage-6.3.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:06f54765cdbce99901871d50fe9f41d58213f18e98b170a30ca34f47de7dd5e8"},
-    {file = "coverage-6.3.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7835f76a081787f0ca62a53504361b3869840a1620049b56d803a8cb3a9eeea3"},
-    {file = "coverage-6.3.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6f5fee77ec3384b934797f1873758f796dfb4f167e1296dc00f8b2e023ce6ee9"},
-    {file = "coverage-6.3.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:baa8be8aba3dd1e976e68677be68a960a633a6d44c325757aefaa4d66175050f"},
-    {file = "coverage-6.3.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4d06380e777dd6b35ee936f333d55b53dc4a8271036ff884c909cf6e94be8b6c"},
-    {file = "coverage-6.3.3-cp39-cp39-win32.whl", hash = "sha256:f8cabc5fd0091976ab7b020f5708335033e422de25e20ddf9416bdce2b7e07d8"},
-    {file = "coverage-6.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c9441d57b0963cf8340268ad62fc83de61f1613034b79c2b1053046af0c5284"},
-    {file = "coverage-6.3.3-pp36.pp37.pp38-none-any.whl", hash = "sha256:d522f1dc49127eab0bfbba4e90fa068ecff0899bbf61bf4065c790ddd6c177fe"},
-    {file = "coverage-6.3.3.tar.gz", hash = "sha256:2781c43bffbbec2b8867376d4d61916f5e9c4cc168232528562a61d1b4b01879"},
+    {file = "coverage-6.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b"},
+    {file = "coverage-6.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4ce1b258493cbf8aec43e9b50d89982346b98e9ffdfaae8ae5793bc112fb0068"},
+    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c4e737f60c6936460c5be330d296dd5b48b3963f48634c53b3f7deb0f34ec4"},
+    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84e65ef149028516c6d64461b95a8dbcfce95cfd5b9eb634320596173332ea84"},
+    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f69718750eaae75efe506406c490d6fc5a6161d047206cc63ce25527e8a3adad"},
+    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e57816f8ffe46b1df8f12e1b348f06d164fd5219beba7d9433ba79608ef011cc"},
+    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:01c5615d13f3dd3aa8543afc069e5319cfa0c7d712f6e04b920431e5c564a749"},
+    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:75ab269400706fab15981fd4bd5080c56bd5cc07c3bccb86aab5e1d5a88dc8f4"},
+    {file = "coverage-6.4.1-cp310-cp310-win32.whl", hash = "sha256:a7f3049243783df2e6cc6deafc49ea123522b59f464831476d3d1448e30d72df"},
+    {file = "coverage-6.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:ee2ddcac99b2d2aec413e36d7a429ae9ebcadf912946b13ffa88e7d4c9b712d6"},
+    {file = "coverage-6.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb73e0011b8793c053bfa85e53129ba5f0250fdc0392c1591fd35d915ec75c46"},
+    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:106c16dfe494de3193ec55cac9640dd039b66e196e4641fa8ac396181578b982"},
+    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87f4f3df85aa39da00fd3ec4b5abeb7407e82b68c7c5ad181308b0e2526da5d4"},
+    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:961e2fb0680b4f5ad63234e0bf55dfb90d302740ae9c7ed0120677a94a1590cb"},
+    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:cec3a0f75c8f1031825e19cd86ee787e87cf03e4fd2865c79c057092e69e3a3b"},
+    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:129cd05ba6f0d08a766d942a9ed4b29283aff7b2cccf5b7ce279d50796860bb3"},
+    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bf5601c33213d3cb19d17a796f8a14a9eaa5e87629a53979a5981e3e3ae166f6"},
+    {file = "coverage-6.4.1-cp37-cp37m-win32.whl", hash = "sha256:269eaa2c20a13a5bf17558d4dc91a8d078c4fa1872f25303dddcbba3a813085e"},
+    {file = "coverage-6.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f02cbbf8119db68455b9d763f2f8737bb7db7e43720afa07d8eb1604e5c5ae28"},
+    {file = "coverage-6.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ffa9297c3a453fba4717d06df579af42ab9a28022444cae7fa605af4df612d54"},
+    {file = "coverage-6.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:145f296d00441ca703a659e8f3eb48ae39fb083baba2d7ce4482fb2723e050d9"},
+    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d44996140af8b84284e5e7d398e589574b376fb4de8ccd28d82ad8e3bea13"},
+    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bd9a6fc18aab8d2e18f89b7ff91c0f34ff4d5e0ba0b33e989b3cd4194c81fd9"},
+    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3384f2a3652cef289e38100f2d037956194a837221edd520a7ee5b42d00cc605"},
+    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9b3e07152b4563722be523e8cd0b209e0d1a373022cfbde395ebb6575bf6790d"},
+    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1480ff858b4113db2718848d7b2d1b75bc79895a9c22e76a221b9d8d62496428"},
+    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:865d69ae811a392f4d06bde506d531f6a28a00af36f5c8649684a9e5e4a85c83"},
+    {file = "coverage-6.4.1-cp38-cp38-win32.whl", hash = "sha256:664a47ce62fe4bef9e2d2c430306e1428ecea207ffd68649e3b942fa8ea83b0b"},
+    {file = "coverage-6.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:26dff09fb0d82693ba9e6231248641d60ba606150d02ed45110f9ec26404ed1c"},
+    {file = "coverage-6.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9c80df769f5ec05ad21ea34be7458d1dc51ff1fb4b2219e77fe24edf462d6df"},
+    {file = "coverage-6.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:39ee53946bf009788108b4dd2894bf1349b4e0ca18c2016ffa7d26ce46b8f10d"},
+    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5b66caa62922531059bc5ac04f836860412f7f88d38a476eda0a6f11d4724f4"},
+    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd180ed867e289964404051a958f7cccabdeed423f91a899829264bb7974d3d3"},
+    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84631e81dd053e8a0d4967cedab6db94345f1c36107c71698f746cb2636c63e3"},
+    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8c08da0bd238f2970230c2a0d28ff0e99961598cb2e810245d7fc5afcf1254e8"},
+    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d42c549a8f41dc103a8004b9f0c433e2086add8a719da00e246e17cbe4056f72"},
+    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:309ce4a522ed5fca432af4ebe0f32b21d6d7ccbb0f5fcc99290e71feba67c264"},
+    {file = "coverage-6.4.1-cp39-cp39-win32.whl", hash = "sha256:fdb6f7bd51c2d1714cea40718f6149ad9be6a2ee7d93b19e9f00934c0f2a74d9"},
+    {file = "coverage-6.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:342d4aefd1c3e7f620a13f4fe563154d808b69cccef415415aece4c786665397"},
+    {file = "coverage-6.4.1-pp36.pp37.pp38-none-any.whl", hash = "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815"},
+    {file = "coverage-6.4.1.tar.gz", hash = "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c"},
 ]
 deprecated = [
     {file = "Deprecated-1.2.13-py2.py3-none-any.whl", hash = "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"},
@@ -1295,8 +1295,8 @@ pyyaml-env-tag = [
     {file = "pyyaml_env_tag-0.1.tar.gz", hash = "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb"},
 ]
 redis = [
-    {file = "redis-4.3.1-py3-none-any.whl", hash = "sha256:84316970995a7adb907a56754d2b92d88fc2d252963dc5ac34c88f0f1a22c25d"},
-    {file = "redis-4.3.1.tar.gz", hash = "sha256:94b617b4cd296e94991146f66fc5559756fbefe9493604f0312e4d3298ac63e9"},
+    {file = "redis-4.3.4-py3-none-any.whl", hash = "sha256:a52d5694c9eb4292770084fa8c863f79367ca19884b329ab574d5cb2036b3e54"},
+    {file = "redis-4.3.4.tar.gz", hash = "sha256:ddf27071df4adf3821c4f2ca59d67525c3a82e5f268bed97b813cb4fabf87880"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ known_first_party = ["mognet"]
 
 [tool.mypy]
 python_version = 3.8
-pretty = true
+strict = true
 
 # Silence errors for third-party packages that don't have
 # typings available.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ mkdocs-material = "^8.2.6"
 mkdocstrings = {version = "^0.18.1", extras = ["python-legacy"]}
 mkdocs-typer = "^0.0.2"
 isort = "^5.10.1"
+types-tabulate = "^0.8.11"
+mypy = "^0.961"
+types-redis = "^4.3.4"
 
 [build-system]
 # Allow the package to be installed with `pip install -e ...`,
@@ -67,3 +70,21 @@ py_version = 38
 profile = "black"
 src_paths = ["mognet", "test"]
 known_first_party = ["mognet"]
+
+[tool.mypy]
+python_version = 3.8
+pretty = true
+
+# Silence errors for third-party packages that don't have
+# typings available.
+[[tool.mypy.overrides]]
+module = "pytest_asyncio.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "aiorun.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "treelib.*"
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ Jinja2 = "<3.1.0" # See https://github.com/mkdocs/mkdocs/issues/2794
 mkdocs-material = "^8.2.6"
 mkdocstrings = {version = "^0.18.1", extras = ["python-legacy"]}
 mkdocs-typer = "^0.0.2"
+isort = "^5.10.1"
 
 [build-system]
 # Allow the package to be installed with `pip install -e ...`,
@@ -55,3 +56,14 @@ requires = [
     "setuptools"
 ]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 88
+target-version = ["py38"]
+include = '\.pyi?$'
+
+[tool.isort]
+py_version = 38
+profile = "black"
+src_paths = ["mognet", "test"]
+known_first_party = ["mognet"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ isort = "^5.10.1"
 types-tabulate = "^0.8.11"
 mypy = "^0.961"
 types-redis = "^4.3.4"
+flake8 = "^4.0.1"
+flake8-bugbear = "^22.7.1"
 
 [build-system]
 # Allow the package to be installed with `pip install -e ...`,

--- a/test/app_instance.py
+++ b/test/app_instance.py
@@ -15,18 +15,18 @@ from mognet.state.state_backend_config import (
 
 
 def get_config():
-    config_file_path = Path(os.getenv("MOGNET_TEST_CONFIG_FILE", "config.json"))
+    config_file_path = Path(os.getenv("MOGNET_CONFIG_FILE", "config.json"))
 
     if config_file_path.is_file():
         return AppConfig.parse_file(config_file_path)
 
     return AppConfig(
         result_backend=ResultBackendConfig(
-            redis=RedisResultBackendSettings(url="redis://redis")
+            redis=RedisResultBackendSettings(url="redis://localhost:6379/0")
         ),
-        broker=BrokerConfig(amqp=AmqpBrokerSettings(url="amqp://rabbitmq")),
+        broker=BrokerConfig(amqp=AmqpBrokerSettings(url="amqp://localhost:5672")),
         state_backend=StateBackendConfig(
-            redis=RedisStateBackendSettings(url="redis://redis")
+            redis=RedisStateBackendSettings(url="redis://localhost:6379/0")
         ),
         task_routes={},
         minimum_concurrency=1,

--- a/test/app_instance.py
+++ b/test/app_instance.py
@@ -1,29 +1,36 @@
-from mognet.state.state_backend_config import (
-    RedisStateBackendSettings,
-    StateBackendConfig,
-)
-from mognet.broker.broker_config import AmqpBrokerSettings, BrokerConfig
+import os
+from pathlib import Path
+
+from mognet.app.app import App
+from mognet.app.app_config import AppConfig
 from mognet.backend.backend_config import (
     RedisResultBackendSettings,
     ResultBackendConfig,
 )
-from mognet.app.app import App
-from mognet.app.app_config import AppConfig
-
-
-config = AppConfig(
-    result_backend=ResultBackendConfig(
-        redis=RedisResultBackendSettings(url="redis://redis")
-    ),
-    broker=BrokerConfig(amqp=AmqpBrokerSettings(url="amqp://rabbitmq")),
-    state_backend=StateBackendConfig(
-        redis=RedisStateBackendSettings(url="redis://redis")
-    ),
-    task_routes={},
-    minimum_concurrency=1,
+from mognet.broker.broker_config import AmqpBrokerSettings, BrokerConfig
+from mognet.state.state_backend_config import (
+    RedisStateBackendSettings,
+    StateBackendConfig,
 )
 
-config.imports = ["test.test_tasks"]
+
+def get_config():
+    config_file_path = Path(os.getenv("MOGNET_TEST_CONFIG_FILE", "config.json"))
+
+    if config_file_path.is_file():
+        return AppConfig.parse_file(config_file_path)
+
+    return AppConfig(
+        result_backend=ResultBackendConfig(
+            redis=RedisResultBackendSettings(url="redis://redis")
+        ),
+        broker=BrokerConfig(amqp=AmqpBrokerSettings(url="amqp://rabbitmq")),
+        state_backend=StateBackendConfig(
+            redis=RedisStateBackendSettings(url="redis://redis")
+        ),
+        task_routes={},
+        minimum_concurrency=1,
+    )
 
 
-app = App(name="test", config=config)
+app = App(name="test", config=get_config())

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,12 +1,12 @@
 import pytest
+
 from mognet.testing.pytest_integration import create_app_fixture
 
-from .app_instance import config, app
-
+from .app_instance import app, get_config
 
 test_app = create_app_fixture(app)
 
 
 @pytest.fixture
 def app_config():
-    return config
+    return get_config()

--- a/test/test_broker.py
+++ b/test/test_broker.py
@@ -1,8 +1,8 @@
-from mognet.exceptions.broker_exceptions import QueueNotFound
-import pytest
-
 from typing import TYPE_CHECKING
 
+import pytest
+
+from mognet.exceptions.broker_exceptions import QueueNotFound
 
 if TYPE_CHECKING:
     from mognet import App

--- a/test/test_broker.py
+++ b/test/test_broker.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 async def test_broker_stats(test_app: "App"):
     stats = await test_app.broker.task_queue_stats("tasks")
 
+    assert stats is not None
+
 
 @pytest.mark.asyncio
 async def test_broker_stats_fails_when_queue_not_found(test_app: "App"):
@@ -21,3 +23,5 @@ async def test_broker_stats_fails_when_queue_not_found(test_app: "App"):
 
     # But subsequent calls should still work...
     stats = await test_app.broker.task_queue_stats("tasks")
+
+    assert stats is not None

--- a/test/test_execution_time.py
+++ b/test/test_execution_time.py
@@ -1,13 +1,12 @@
-from datetime import timedelta, datetime, timezone
-from mognet.exceptions.result_exceptions import Revoked
-from mognet.model.result_state import ResultState
 import time
-import pytest
-
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
-from mognet import Request
+import pytest
 
+from mognet import Request
+from mognet.exceptions.result_exceptions import Revoked
+from mognet.model.result_state import ResultState
 
 if TYPE_CHECKING:
     from mognet import App

--- a/test/test_pausing.py
+++ b/test/test_pausing.py
@@ -1,8 +1,10 @@
-import pytest
 from typing import List
-from mognet.primitives.request import Request
+
+import pytest
+
 from mognet import App, Context, task
 from mognet.exceptions.task_exceptions import Pause
+from mognet.primitives.request import Request
 
 
 @task(name="test.paused_sum")

--- a/test/test_recursion.py
+++ b/test/test_recursion.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mognet import task, Request, App, Context
+from mognet import App, Context, Request, task
 
 
 @task(name="test.recursive_factorial")

--- a/test/test_result_backend.py
+++ b/test/test_result_backend.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Type
 from uuid import uuid4
 
 import pytest

--- a/test/test_result_backend.py
+++ b/test/test_result_backend.py
@@ -1,6 +1,7 @@
+from dataclasses import dataclass
 from typing import Type
 from uuid import uuid4
-from dataclasses import dataclass
+
 import pytest
 import pytest_asyncio
 

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,8 +1,10 @@
 import os
+
+import pytest
+
+from mognet import App, Context, Request, task
 from mognet.exceptions.too_many_retries import TooManyRetries
 from mognet.model.result_state import ResultState
-import pytest
-from mognet import App, Request, task, Context
 
 
 @pytest.mark.asyncio

--- a/test/test_revoke.py
+++ b/test/test_revoke.py
@@ -1,9 +1,11 @@
 import asyncio
 import uuid
+
+import pytest
+
+from mognet import App, Context, Request, task
 from mognet.model.result import ResultFailed
 from mognet.model.result_state import ResultState
-import pytest
-from mognet import App, Request, Context, task
 
 
 @pytest.mark.asyncio

--- a/test/test_sync_tasks.py
+++ b/test/test_sync_tasks.py
@@ -1,9 +1,11 @@
 import asyncio
-import pytest
 import time
-from mognet import task, Context, App, Request
-from mognet.model.result_state import ResultState
 from test.test_tasks import add
+
+import pytest
+
+from mognet import App, Context, Request, task
+from mognet.model.result_state import ResultState
 
 
 @task(name="test.sync_slow_add")

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -1,7 +1,6 @@
 import asyncio
 
 from mognet import Context
-
 from mognet.decorators.task_decorator import task
 
 

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
+
+import pytest
 from pydantic.main import BaseModel
+
+from mognet import App, Context, Request, task
 from mognet.exceptions.task_exceptions import InvalidTaskArguments
 from mognet.model.result_state import ResultState
 from mognet.tasks.task_registry import UnknownTask
-import pytest
-from mognet import App, Request, task, Context
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This does a few changes, and should probably be split into multiple PRs for digestibility.

- It moves away from `aioredis` to `redis-py`, because the former is deprecated and moved into the main package
- It updates pinned dependencies (dependency requirements of the package didn't actually change apart from `aioredis`)
- It applies `isort` for sorting imports. Because of the large diff, an "ignore revs" file has been created
- It tries to be more local-development friendly by allowing the configuration to be set externally and by having a dedicated `docker-compose.yaml` file just for Redis and RabbitMQ
- It adds a `Makefile` with common commands to format code, lint, and test
- Update links to match the new org

Still want to implement:

- MyPy for type checking
- Update CI to run linting and testing automatically