### PR TITLE
Change URLs to new GH org

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,6 @@ authors:
     given-names: DeepSearch
 title: "Project Mognet"
 version: 1.3.1
-url: "https://github.com/IBM/project-mognet"
+url: "https://github.com/DS4SD/project-mognet"
 # doi: TBD
 date-released: 2022-04-25

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 Our project welcomes external contributions. If you have an itch, please feel
 free to scratch it.
 
-To contribute code or documentation, please submit a [pull request](https://github.com/IBM/project-mognet/pulls).
+To contribute code or documentation, please submit a [pull request](https://github.com/DS4SD/project-mognet/pulls).
 
 A good way to familiarize yourself with the codebase and contribution process is
-to look for and tackle low-hanging fruit in the [issue tracker](https://github.com/IBM/project-mognet/issues).
+to look for and tackle low-hanging fruit in the [issue tracker](https://github.com/DS4SD/project-mognet/issues).
 Before embarking on a more ambitious contribution, please quickly [get in touch](#communication) with us.
 
-For general questions or support requests, please refer to the [discussion section](https://github.com/IBM/project-mognet/discussions).
+For general questions or support requests, please refer to the [discussion section](https://github.com/DS4SD/project-mognet/discussions).
 
 **Note: We appreciate your effort, and want to avoid a situation where a contribution
 requires extensive rework (by you or by us), sits in backlog for a long time, or
@@ -16,14 +16,14 @@ cannot be accepted at all!**
 
 ### Proposing new features
 
-If you would like to implement a new feature, please [raise an issue](https://github.com/IBM/project-mognet/issues)
+If you would like to implement a new feature, please [raise an issue](https://github.com/DS4SD/project-mognet/issues)
 before sending a pull request so the feature can be discussed. This is to avoid
 you wasting your valuable time working on a feature that the project developers
 are not interested in accepting into the code base.
 
 ### Fixing bugs
 
-If you would like to fix a bug, please [raise an issue](https://github.com/IBM/project-mognet/issues) before sending a
+If you would like to fix a bug, please [raise an issue](https://github.com/DS4SD/project-mognet/issues) before sending a
 pull request so it can be tracked.
 
 ### Merge approval
@@ -74,7 +74,7 @@ git commit -s
 
 ## Communication
 
-Please feel free to connect with us using the [discussion section](https://github.com/IBM/project-mognet/discussions).
+Please feel free to connect with us using the [discussion section](https://github.com/DS4SD/project-mognet/discussions).
 
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install mognet
 
 ## Getting Started and Documentation
 
-We recommend having a look at the [Documentation](https://ibm.github.io/project-mognet/).
+We recommend having a look at the [Documentation](https://ds4sd.github.io/project-mognet/).
 
 ## Contributing
 
@@ -28,7 +28,7 @@ If you use `Mognet` in your projects, please consider citing the following:
 author = {DeepSearch Team},
 month = {4},
 title = {{Project Mognet}},
-url = {https://github.com/IBM/project-mognet},
+url = {https://github.com/DS4SD/project-mognet},
 version = {main},
 year = {2022}
 }

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # Mognet Demo
 
-This is a demo application for [Mognet](https://github.ibm.com/CognitiveCore-Utilities/project-mognet). It consists of a REST API, implemented with [FastAPI](https://fastapi.tiangolo.com/), that receives files to process, and a Mognet backend, that will process the files.
+This is a demo application for [Mognet](https://github.com/DS4SD/project-mognet). It consists of a REST API, implemented with [FastAPI](https://fastapi.tiangolo.com/), that receives files to process, and a Mognet backend, that will process the files.
 
 ## Installing
 

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -30,7 +30,7 @@ isort==5.10.1; python_full_version >= "3.6.2" and python_version < "4.0"
 jmespath==1.0.0; python_version >= "3.7"
 lazy-object-proxy==1.7.1; python_version >= "3.6" and python_full_version >= "3.6.2"
 mccabe==0.6.1; python_full_version >= "3.6.2"
-mognet @ git+ssh://git@github.ibm.com/CognitiveCore-Utilities/project-mognet.git@val/quality-of-life-improvements ; python_version >= "3.8" and python_version < "4.0"
+mognet==1.3.2
 motor==2.5.1; python_full_version >= "3.5.2"
 multidict==6.0.2; python_version >= "3.7"
 mypy-extensions==0.4.3; python_full_version >= "3.6.2"

--- a/docs/advanced/middleware.md
+++ b/docs/advanced/middleware.md
@@ -39,4 +39,4 @@ app.add_middleware(MyMiddleware())
 
 ## A more concrete example
 
-See [`AutoShutdownMiddleware`](https://github.ibm.com/CognitiveCore-Utilities/mognet-demo/blob/457dd98ebb284ae1e96bc30190c718b18ed5050d/mognet_demo/middleware/auto_shutdown.py#L28). This class implements a common pattern for long running applications: periodic restarts to release memory, due to Python's memory model.
+See [`AutoShutdownMiddleware`](https://github.com/DS4SD/project-mognet/blob/main/demo/mognet_demo/middleware/auto_shutdown.py#L28). This class implements a common pattern for long running applications: periodic restarts to release memory, due to Python's memory model.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,4 +4,4 @@
 
 This example defines a FastAPI server for a REST API that processes files, in the background, using Mognet.
 
-It is available here: [https://github.com/IBM/project-mognet/tree/main/demo/](https://github.com/IBM/project-mognet/tree/main/demo/)
+It is available here: [https://github.com/DS4SD/project-mognet/tree/main/demo/](https://github.com/DS4SD/project-mognet/tree/main/demo/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ description = "Mognet is a fast, simple framework to build distributed applicati
 authors = ["André Carvalho <afecarvalho@gmail.com>", "Christoph Auer <cau@zurich.ibm.com>", "Michele Dolfi <dol@zurich.ibm.com>", "Peter Staar <taa@zurich.ibm.com>"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://ibm.github.io/project-mognet/"
-repository = "https://github.com/IBM/project-mognet"
-documentation = "https://ibm.github.io/project-mognet/"
+homepage = "https://ds4sd.github.io/project-mognet/"
+repository = "https://github.com/DS4SD/project-mognet"
+documentation = "https://ds4sd.github.io/project-mognet/"
 classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Version Control :: Git",


### PR DESCRIPTION
Remapping the URLs from `github.com/ibm` to `github.com/ds4sd`